### PR TITLE
2025-05-26: Refactor Glance highlight overrides and add shared theme palette utility

### DIFF
--- a/v2/nvim/lua/johnmutuma/plugins/lsp/copilot-chat.lua
+++ b/v2/nvim/lua/johnmutuma/plugins/lsp/copilot-chat.lua
@@ -54,12 +54,16 @@ return {
                             vim.ui.select(options, { prompt = "Select anchor to diff against: " }, callback)
                         end,
                         resolve = function(input, source)
-                            local diff = git_utils.get_git_diff(input, source.cwd())
+                            local cwd = source.cwd()
+                            local diff = git_utils.get_git_diff(input, cwd)
+                            local content = diff or "No changes detected"
+                            local filename = string.format("git_diff-@-%s", input)
+
                             return {
                                 {
-                                    content = diff,
+                                    content = content,
                                     filetype = "diff",
-                                    filename = "git_diff-@-" .. input,
+                                    filename = filename,
                                 },
                             }
                         end,

--- a/v2/nvim/lua/johnmutuma/plugins/lsp/glance.lua
+++ b/v2/nvim/lua/johnmutuma/plugins/lsp/glance.lua
@@ -9,6 +9,7 @@ return {
     config = function()
         local glance = require("glance")
         local window_utils = require("johnmutuma.utils.windows")
+        local palette = require("johnmutuma.utils.theme").palette
 
         ----------------------------------------------------------------------
         -- Glance Setup
@@ -25,32 +26,31 @@ return {
         ----------------------------------------------------------------------
         -- Highlight Overrides Based on Colorscheme
         ----------------------------------------------------------------------
+
         local function setHighlightOverrides()
             local bg = vim.opt.background:get()
-            if bg == "light" then
-                vim.cmd([[
-                  hi GlanceBorderTop gui=underline guifg=black guibg=white
-                  hi GlanceWinBarFilepath gui=italic guibg=#c1c1c1
-                  hi GlanceWinBarFilename gui=italic guifg=black guibg=#c1c1c1
-                  hi GlanceWinBarTitle gui=bold guifg=#010101 guibg=#c1c1c1
-                  hi GlancePreviewBorderBottom gui=underline guifg=black
-                  hi GlanceListCursorLine gui=none guibg=#aaaaaa
-                  hi GlanceListBorderBottom gui=underline guifg=black
-                  hi GlanceListNormal gui=italic guifg=indigo
-                ]])
-                return
+            local c = palette[bg == "light" and "light" or "dark"]
+
+            local highlights = {
+                GlanceBorderTop = { gui = "underline", guifg = c.border, guibg = c.border_bg },
+                GlanceWinBarFilepath = { gui = "italic", guibg = c.highlight },
+                GlanceWinBarFilename = { gui = "italic", guifg = c.fg, guibg = c.highlight },
+                GlanceWinBarTitle = { gui = "bold", guifg = c.fg, guibg = c.highlight },
+                GlancePreviewBorderBottom = { gui = "underline", guifg = c.border },
+                GlanceListCursorLine = { gui = "none", guibg = c.subtle },
+                GlanceListBorderBottom = { gui = "underline", guifg = c.border },
+                GlanceListNormal = { gui = "italic", guifg = c.accent },
+            }
+
+            for group, opts in pairs(highlights) do
+                local cmd = "hi " .. group
+                for k, v in pairs(opts) do
+                    if v and v ~= "" then
+                        cmd = cmd .. " " .. k .. "=" .. v
+                    end
+                end
+                vim.cmd(cmd)
             end
-            -- dark theme
-            vim.cmd([[
-              hi GlanceBorderTop gui=underline guifg=#b5bcbd guibg=#10110A
-              hi GlanceWinBarFilepath gui=italic guibg=#14140F
-              hi GlanceWinBarFilename gui=none guibg=#14140F
-              hi GlanceWinBarTitle gui=none guibg=#14140F
-              hi GlancePreviewBorderBottom gui=underline guifg=#b5bcbd
-              hi GlanceListCursorLine gui=none guibg=#656661
-              hi GlanceListBorderBottom gui=underline guifg=#b5bcbd
-              hi GlanceListNormal gui=italic guifg=e1e1e1
-            ]])
         end
 
         setHighlightOverrides()

--- a/v2/nvim/lua/johnmutuma/utils/theme.lua
+++ b/v2/nvim/lua/johnmutuma/utils/theme.lua
@@ -1,0 +1,35 @@
+----------------------------------------------------------------------
+-- 1 & 2. Generic Theme Palette
+----------------------------------------------------------------------
+local M = {}
+
+M.palette = {
+    light = {
+        fg = "#010101",
+        bg = "#ffffff",
+        border = "black",
+        border_bg = "white",
+        accent = "indigo",
+        muted = "#c1c1c1",
+        subtle = "#aaaaaa",
+        highlight = "#c1c1c1",
+        error = "red",
+        info = "blue",
+        warning = "orange",
+    },
+    dark = {
+        fg = "#e1e1e1",
+        bg = "#10110A",
+        border = "#b5bcbd",
+        border_bg = "#10110A",
+        accent = "#b5bcbd",
+        muted = "#14140F",
+        subtle = "#656661",
+        highlight = "#14140F",
+        error = "red",
+        info = "blue",
+        warning = "orange",
+    },
+}
+
+return M


### PR DESCRIPTION
## What does this PR do?
This PR refactors the highlight override logic for the Glance plugin to use a centralized theme palette, and introduces a new utility module for theme colors. It also improves the Copilot Chat plugin's git diff provider to handle empty diffs more gracefully.

### Changes made in this PR:
- **Glance Plugin:**
  - Refactored highlight override logic to use a Lua table driven by a shared palette, instead of hardcoded Vim commands.
  - Imports and uses a new `palette` from `johnmutuma.utils.theme` for consistent color management across light and dark themes.
- **Copilot Chat Plugin:**
  - Improved the git diff provider to return "No changes detected" when there are no changes, instead of returning `nil`.
  - Cleaned up filename formatting for git diff buffers.
- **New Utility Module:**
  - Added `johnmutuma.utils.theme.lua` which exports a `palette` table for both light and dark themes, centralizing color definitions for easier maintenance.

## Why is it needed?
- Centralizes and simplifies theme color management, making it easier to maintain and update highlight groups across plugins.
- Improves code readability and maintainability by removing duplicated and hardcoded highlight commands.
- Handles edge cases in Copilot Chat's git diff provider, improving user experience and preventing errors when no changes are detected.

## How have the changes been tested?
- Manually tested in Neovim with both light and dark backgrounds.
- Verified that Glance highlights update correctly when switching themes.
- Confirmed that Copilot Chat's git diff provider displays "No changes detected" when appropriate and uses the correct filename format.

## Screenshots (if applicable)
N/A (UI changes are color-related and context-specific).

## Checklist
- [x] Centralized theme palette created and used in Glance plugin
- [x] Glance highlight overrides refactored to use palette
- [x] Copilot Chat git diff provider improved for empty diffs
- [x] All code changes tested in both light and dark modes
- [x] No breaking changes introduced

