### PR TITLE
2025-05-26: UI Consistency Improvements for Git and Glance Plugins

### DIFF
--- a/v2/nvim/lua/nairovim/plugins/gitsigns.lua
+++ b/v2/nvim/lua/nairovim/plugins/gitsigns.lua
@@ -10,7 +10,7 @@ return {
         ----------------------------------------------------------------------
         require("gitsigns").setup({
             preview_config = {
-                border = "single",
+                border = "rounded",
             },
             on_attach = function(bufnr)
                 local gs = package.loaded.gitsigns

--- a/v2/nvim/lua/nairovim/plugins/lazygit.lua
+++ b/v2/nvim/lua/nairovim/plugins/lazygit.lua
@@ -1,4 +1,4 @@
-local globl = vim.g
+local g = vim.g
 local keymap = vim.keymap
 
 return {
@@ -11,9 +11,25 @@ return {
     init = function()
         local window_utils = require("nairovim.utils.windows")
 
-        globl.lazygit_floating_window_winblend = 4 -- transparency of floating window
-        globl.lazygit_floating_window_scaling_factor = 0.85 -- scaling factor for floating window
-        keymap.set("n", "<leader>G", ":LazyGit<CR>", {})
+        g.lazygit_floating_window_winblend = 4 -- transparency of floating window
+        g.lazygit_floating_window_scaling_factor = 0.85 -- scaling factor for floating window
+        keymap.set("n", "<leader>G", ":LazyGit<CR>")
+
+        local function set_lazygit_border_highlight()
+            vim.api.nvim_set_hl(0, "LazyGitBorder", { link = "FloatBorder" })
+            -- Add your custom highlights here
+        end
+
+        -- Set highlight on startup
+        set_lazygit_border_highlight()
+
+        -- Set highlight on colorscheme change
+        local lazygit_hl_augroup = vim.api.nvim_create_augroup("LazyGitHighlightOverrides", { clear = true })
+        vim.api.nvim_create_autocmd("ColorScheme", {
+            pattern = "*",
+            group = lazygit_hl_augroup,
+            callback = set_lazygit_border_highlight,
+        })
 
         -- manually adding a backdrop to lazygit prompt to add depth
         -- can remove this when Telescope has added a backdrop internally or if neovim decideds to include backdrops to floating windows for depth

--- a/v2/nvim/lua/nairovim/plugins/lsp/glance.lua
+++ b/v2/nvim/lua/nairovim/plugins/lsp/glance.lua
@@ -18,8 +18,10 @@ return {
             detached = true,
             border = {
                 enable = true,
-                top_char = "~",
-                bottom_char = " ",
+            },
+            theme = {
+                enable = true,
+                mode = "auto",
             },
         })
 
@@ -32,14 +34,11 @@ return {
             local c = palette[bg == "light" and "light" or "dark"]
 
             local highlights = {
-                GlanceBorderTop = { gui = "underline", guifg = c.border, guibg = c.border_bg },
                 GlanceWinBarFilepath = { gui = "italic", guibg = c.highlight },
                 GlanceWinBarFilename = { gui = "italic", guifg = c.fg, guibg = c.highlight },
                 GlanceWinBarTitle = { gui = "bold", guifg = c.fg, guibg = c.highlight },
-                GlancePreviewBorderBottom = { gui = "underline", guifg = c.border },
-                GlanceListCursorLine = { gui = "none", guibg = c.subtle },
-                GlanceListBorderBottom = { gui = "underline", guifg = c.border },
-                GlanceListNormal = { gui = "italic", guifg = c.accent },
+                -- GlanceListCursorLine = { gui = "none", guibg = c.subtle },
+                GlanceListNormal = { gui = "italic" },
             }
 
             for group, opts in pairs(highlights) do
@@ -51,6 +50,10 @@ return {
                 end
                 vim.cmd(cmd)
             end
+
+            vim.api.nvim_set_hl(0, "GlanceBorderTop", { link = "FloatBorder" })
+            vim.api.nvim_set_hl(0, "GlancePreviewBorderBottom", { link = "FloatBorder" })
+            vim.api.nvim_set_hl(0, "GlanceListBorderBottom", { link = "FloatBorder" })
         end
 
         setHighlightOverrides()


### PR DESCRIPTION
## What does this PR do?
This PR introduces several UI consistency improvements for the gitsigns, lazygit, and glance.nvim plugins in the Neovim configuration. The changes focus on harmonizing border styles, highlight groups, and theme handling to provide a more cohesive and visually appealing user experience.

### Changes made in this PR:
- **gitsigns.nvim**:  
  - Changed the preview window border style from "single" to "rounded" for a more modern look.
- **lazygit.nvim**:  
  - Refactored variable naming for clarity (`globl` → `g`).
  - Improved keymap setup for `<leader>G`.
  - Added highlight override for the `LazyGitBorder` group, linking it to `FloatBorder`.
  - Ensured highlight is set on startup and on colorscheme changes via autocommand.
- **glance.nvim**:  
  - Updated border configuration to use the new theme system (`theme.enable` and `theme.mode`).
  - Removed custom border characters in favor of plugin defaults.
  - Simplified and improved highlight overrides:
    - Linked `GlanceBorderTop`, `GlancePreviewBorderBottom`, and `GlanceListBorderBottom` to `FloatBorder`.
    - Cleaned up and commented out unused highlight groups.
    - Ensured highlight overrides are applied on setup.

## Why is it needed?
- To provide a consistent and modern UI across git-related and LSP glance windows.
- To ensure highlight groups adapt correctly to colorscheme changes.
- To simplify and future-proof highlight and border configuration as plugins evolve.

## How have the changes been tested?
- Manually verified border styles and highlights in Neovim with various colorschemes.
- Confirmed that highlight overrides persist after changing colorschemes.
- Checked that plugin functionality remains intact and visually consistent.

## Screenshots (if applicable)
N/A (UI changes are subtle and best observed in-editor).

## Checklist
- [x] Borders are consistent and visually appealing across plugins.
- [x] Highlight groups are correctly linked and update on colorscheme changes.
- [x] No breaking changes to plugin functionality.
- [x] Code is refactored for clarity and maintainability.

---