### PR TITLE
2025-05-27: Refactor highlight modules to use unified getter function

### DIFF
--- a/v2/nvim/lua/nairovim/plugins/customizations/highlights/glance.lua
+++ b/v2/nvim/lua/nairovim/plugins/customizations/highlights/glance.lua
@@ -2,18 +2,20 @@ local palette = require("nairovim.utils.theme").palette
 
 local M = {}
 
-local bg = vim.opt.background:get()
-local c = palette[bg == "light" and "light" or "dark"]
+function M.get()
+    local bg = vim.opt.background:get()
+    local c = palette[bg == "light" and "light" or "dark"]
 
---- @type nairovim.highlightspec
-M.highlights = {
-    GlanceWinBarFilepath = { italic = true, bg = c.highlight },
-    GlanceWinBarFilename = { italic = true, fg = c.fg, bg = c.highlight },
-    GlanceWinBarTitle = { bold = true, fg = c.fg, bg = c.highlight },
-    GlanceListNormal = { italic = true },
-    GlanceBorderTop = { link = "FloatBorder" },
-    GlancePreviewBorderBottom = { link = "FloatBorder" },
-    GlanceListBorderBottom = { link = "FloatBorder" },
-}
+    --- @type nairovim.highlightspec
+    return {
+        GlanceWinBarFilepath = { italic = true, bg = c.highlight },
+        GlanceWinBarFilename = { italic = true, fg = c.fg, bg = c.highlight },
+        GlanceWinBarTitle = { bold = true, fg = c.fg, bg = c.highlight },
+        GlanceListNormal = { italic = true },
+        GlanceBorderTop = { link = "FloatBorder" },
+        GlancePreviewBorderBottom = { link = "FloatBorder" },
+        GlanceListBorderBottom = { link = "FloatBorder" },
+    }
+end
 
 return M

--- a/v2/nvim/lua/nairovim/plugins/customizations/highlights/lazygit.lua
+++ b/v2/nvim/lua/nairovim/plugins/customizations/highlights/lazygit.lua
@@ -1,10 +1,10 @@
-local palette = require("nairovim.utils.theme").palette
-
 local M = {}
 
---- @type nairovim.highlightspec
-M.highlights = {
-    LazyGitBorder = { link = "FloatBorder" },
-}
+function M.get()
+    --- @type nairovim.highlightspec
+    return {
+        LazyGitBorder = { link = "FloatBorder" },
+    }
+end
 
 return M

--- a/v2/nvim/lua/nairovim/plugins/customizations/highlights/nvim-tree.lua
+++ b/v2/nvim/lua/nairovim/plugins/customizations/highlights/nvim-tree.lua
@@ -1,9 +1,10 @@
 local M = {}
 ---
---- @type nairovim.highlightspec
-M.highlights = {
-    NvimTreeGitDirtyIcon = { fg = "red" },
-    NvimTreeModifiedIcon = { fg = "red" },
-}
-
+function M.get()
+    --- @type nairovim.highlightspec
+    return {
+        NvimTreeGitDirtyIcon = { fg = "red" },
+        NvimTreeModifiedIcon = { fg = "red" },
+    }
+end
 return M

--- a/v2/nvim/lua/nairovim/plugins/lazygit.lua
+++ b/v2/nvim/lua/nairovim/plugins/lazygit.lua
@@ -18,9 +18,7 @@ return {
         common_utils.map(mappings)
 
         -- Highlight groups for LazyGit
-        local function get_hightlights()
-            return require("nairovim.plugins.customizations.highlights.lazygit").highlights
-        end
+        local get_hightlights = require("nairovim.plugins.customizations.highlights.lazygit").get
         common_utils.apply_highlights(get_hightlights, "lazygit_highlights_overrides_augroup")
 
         -- manually adding a backdrop to lazygit prompt to add depth

--- a/v2/nvim/lua/nairovim/plugins/lsp/glance.lua
+++ b/v2/nvim/lua/nairovim/plugins/lsp/glance.lua
@@ -27,9 +27,7 @@ return {
         ----------------------------------------------------------------------
         -- Highlight Overrides Based on Colorscheme
         ----------------------------------------------------------------------
-        local function get_hightlights()
-            return require("nairovim.plugins.customizations.highlights.glance").highlights
-        end
+        local get_hightlights = require("nairovim.plugins.customizations.highlights.glance").get
 
         local common_utils = require("nairovim.utils.common")
         common_utils.apply_highlights(get_hightlights, "glance_highlights_overrides_augroup")

--- a/v2/nvim/lua/nairovim/plugins/nvim-tree.lua
+++ b/v2/nvim/lua/nairovim/plugins/nvim-tree.lua
@@ -43,9 +43,7 @@ return {
         common_utils.map(mappings)
 
         -- Highlight groups for NvimTree
-        local function get_hightlights()
-            return require("nairovim.plugins.customizations.highlights.nvim-tree").highlights
-        end
+        local get_hightlights = require("nairovim.plugins.customizations.highlights.nvim-tree").get
         common_utils.apply_highlights(get_hightlights, "nvim-tree_highlights_overrides_augroup")
     end,
 }


### PR DESCRIPTION
## What does this PR do?
This PR refactors the highlight customization modules for Glance, LazyGit, and NvimTree to use a consistent getter function (`get()`) for returning highlight specifications. The previous approach of exporting a static `M.highlights` table is replaced with a `get()` function, allowing for more dynamic and maintainable highlight definitions. All plugin setup code is updated to use the new getter function when applying highlights.

### Changes made in this PR:
- Converted `M.highlights` tables to `M.get()` functions in:
  - `plugins/customizations/highlights/glance.lua`
  - `plugins/customizations/highlights/lazygit.lua`
  - `plugins/customizations/highlights/nvim-tree.lua`
- Updated plugin modules to use the new `get` function:
  - `plugins/lsp/glance.lua`
  - `plugins/lazygit.lua`
  - `plugins/nvim-tree.lua`

## Why is it needed?
- Ensures a consistent and extensible pattern for highlight definitions across custom modules.
- Allows highlight groups to be computed dynamically if needed (e.g., based on colorscheme or background).
- Simplifies highlight application logic in plugin setup code.
- Improves maintainability and readability of highlight customization code.

## How have the changes been tested?
- Manually verified that highlights are correctly applied for Glance, LazyGit, and NvimTree after the refactor.
- Checked that no errors occur during plugin initialization and highlight application.
- Confirmed that highlight overrides respond correctly to colorscheme/background changes.

## Screenshots (if applicable)
N/A

## Checklist
- [x] Refactored highlight modules to use `get()` function
- [x] Updated all plugin setup code to use new getter
- [x] Verified highlight application works as expected
- [x] Code is consistent and maintainable
- [x] PR description and title follow project conventions

---