### PR TITLE
2025-06-02: Refactor window backdrop utility and improve plugin UI settings

### DIFF
--- a/v2/nvim/lua/nairovim/plugins/init.lua
+++ b/v2/nvim/lua/nairovim/plugins/init.lua
@@ -44,7 +44,10 @@ return {
             "folke/which-key.nvim",
             event = "VeryLazy",
             opts = {
-                delay = 700,
+                delay = 850,
+                win = {
+                    border = "rounded",
+                },
             },
         },
         {

--- a/v2/nvim/lua/nairovim/plugins/lsp/copilot-chat.lua
+++ b/v2/nvim/lua/nairovim/plugins/lsp/copilot-chat.lua
@@ -81,13 +81,22 @@ return {
             -- 3. Autocmds (Grouped)
             ----------------------------------------------------------------------
             -- Buffer-local options for CopilotChat windows
+
+            -- Create an augroup for copilot chat buffer settings
+            local copilot_chat_group = vim.api.nvim_create_augroup("CopilotChatBufferOptions", { clear = true })
             vim.api.nvim_create_autocmd("BufEnter", {
+                group = copilot_chat_group,
                 pattern = { "copilot-chat", "copilot-overlay" },
                 callback = function()
-                    vim.opt_local.relativenumber = false
-                    vim.opt_local.number = false
-                    vim.opt_local.colorcolumn = ""
-                    vim.opt_local.conceallevel = 0
+                    local opts = {
+                        relativenumber = false,
+                        number = false,
+                        colorcolumn = "",
+                        conceallevel = 0,
+                    }
+                    for k, v in pairs(opts) do
+                        vim.opt_local[k] = v
+                    end
                 end,
             })
 

--- a/v2/nvim/lua/nairovim/utils/windows.lua
+++ b/v2/nvim/lua/nairovim/utils/windows.lua
@@ -6,19 +6,41 @@ local vim = vim
 local M = {}
 
 -- Creates a semi-transparent backdrop for popup windows
+----------------------------------------------------------------------
+-- 1. with_win_backdrop: Add a semi-transparent backdrop to a window
+----------------------------------------------------------------------
+--- Adds a semi-transparent backdrop behind a target floating window.
+--  This function creates a scratch buffer and opens it as a floating window
+--  behind the specified target window (by filetype or buffer pattern).
+--  The backdrop is styled with a dark, semi-transparent background and is
+--  automatically closed when the reference buffer is closed or left.
+--
+--  @param target_win (string) The filetype or buffer pattern for the target window.
+--  @usage
+--      require('nairovim.utils.windows').with_win_backdrop('NvimTree')
 function M.with_win_backdrop(target_win)
     local blend = 60
     local default_zIndex = 40
+    local backdrop_name = target_win .. "_backdrop"
+    local augroup_name = "WinBackdrop_" .. target_win
+
+    -- Set highlight for the backdrop once (if not already set)
+    if not vim.api.nvim_get_hl(0, { name = backdrop_name, link = false }) then
+        vim.api.nvim_set_hl(0, backdrop_name, { bg = "#000000", default = true })
+    end
+
+    -- Create or clear the augroup for this target_win
+    local group = vim.api.nvim_create_augroup(augroup_name, { clear = true })
 
     vim.api.nvim_create_autocmd({ "FileType", "BufWinEnter" }, {
         pattern = target_win,
+        group = group,
         callback = function(ctx)
-            local backdrop_name = target_win .. "_backdrop"
-            local bufnr = ctx.buf
+            local ref_bufnr = ctx.buf
 
             -- Create a scratch buffer for the backdrop
             local backdrop_bufnr = vim.api.nvim_create_buf(false, true)
-            local winnr = vim.api.nvim_open_win(backdrop_bufnr, false, {
+            local backdrop_winid = vim.api.nvim_open_win(backdrop_bufnr, false, {
                 relative = "editor",
                 row = 0,
                 col = 0,
@@ -29,27 +51,27 @@ function M.with_win_backdrop(target_win)
                 zindex = default_zIndex - 1, -- ensure it's below the reference window
             })
 
-            -- Set highlight for the backdrop (only if not already set)
-            if not vim.api.nvim_get_hl(0, { name = backdrop_name, link = false }) then
-                vim.api.nvim_set_hl(0, backdrop_name, { bg = "#000000", default = true })
-            end
-
-            vim.wo[winnr].winhighlight = "Normal:" .. backdrop_name
-            vim.wo[winnr].winblend = blend
+            -- Style the backdrop window
+            vim.wo[backdrop_winid].winhighlight = "Normal:" .. backdrop_name
+            vim.wo[backdrop_winid].winblend = blend
             vim.bo[backdrop_bufnr].buftype = "nofile"
+
+            -- Cleanup function to close backdrop window and buffer
+            local function cleanup()
+                if vim.api.nvim_win_is_valid(backdrop_winid) then
+                    vim.api.nvim_win_close(backdrop_winid, true)
+                end
+                if vim.api.nvim_buf_is_valid(backdrop_bufnr) then
+                    vim.api.nvim_buf_delete(backdrop_bufnr, { force = true })
+                end
+            end
 
             -- Close backdrop when the reference buffer is closed or left
             vim.api.nvim_create_autocmd({ "WinClosed", "BufLeave" }, {
                 once = true,
-                buffer = bufnr,
-                callback = function()
-                    if vim.api.nvim_win_is_valid(winnr) then
-                        vim.api.nvim_win_close(winnr, true)
-                    end
-                    if vim.api.nvim_buf_is_valid(backdrop_bufnr) then
-                        vim.api.nvim_buf_delete(backdrop_bufnr, { force = true })
-                    end
-                end,
+                buffer = ref_bufnr,
+                group = group,
+                callback = cleanup,
             })
         end,
     })


### PR DESCRIPTION
## What does this PR do?
This PR refines the window backdrop utility function and improves UI/UX settings for certain plugins. The changes enhance the reliability and maintainability of the window backdrop feature, and tweak plugin options for a more polished user experience.

### Changes made in this PR:
- Refactored `with_win_backdrop` in `utils/windows.lua`:
  - Improved highlight group and augroup management for backdrops.
  - Ensured proper z-index layering for backdrop windows.
  - Added robust cleanup logic for backdrop buffers and windows.
  - Enhanced documentation and parameter usage.
- Updated `which-key.nvim` plugin options:
  - Increased delay from 700ms to 850ms.
  - Set the popup window border to "rounded" for better aesthetics.
- Improved CopilotChat buffer-local settings:
  - Grouped buffer-local option autocmds under a dedicated augroup.
  - Refactored buffer option assignment for clarity and maintainability.

## Why is it needed?
- The window backdrop utility is now more reliable and easier to maintain, ensuring that backdrop windows are always properly managed and cleaned up.
- UI tweaks to plugins like `which-key.nvim` and CopilotChat provide a more visually appealing and consistent user experience.

## How have the changes been tested?
- Manually tested opening and closing floating windows (e.g., NvimTree) to verify that the backdrop appears and is cleaned up as expected.
- Verified that plugin popups (which-key, CopilotChat) display with the intended UI changes and that buffer-local options are set correctly.

## Screenshots (if applicable)
N/A

## Checklist
- [x] Code compiles and runs as expected
- [x] Backdrop utility cleans up resources properly
- [x] Plugin UI changes are visible and functional
- [x] Documentation/comments updated where necessary