### PR TITLE
2025-06-16: Refine leader key and docstring formatting for clarity

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,6 +12,9 @@
 ----------------------------------------------------------------------
 ```
 
+- when generating docstrings or luadoc, prefix the comment with `---`
+
+
 ## Pull Requests and Commit  Message Format
 
 ### Instructions for commit messages for plugin update with lazy.nvim

--- a/v2/nvim/lua/nairovim/core/options.lua
+++ b/v2/nvim/lua/nairovim/core/options.lua
@@ -5,7 +5,7 @@ local opt = vim.opt
 local g = vim.g
 
 g.mapleader = ","
-g.maplocalleader = "<space>"
+g.maplocalleader = " "
 
 ----------------------------------------------------------------------
 -- 2. Shell

--- a/v2/nvim/lua/nairovim/utils/common.lua
+++ b/v2/nvim/lua/nairovim/utils/common.lua
@@ -74,9 +74,23 @@ function M.run_command(cmd)
     return result
 end
 
+----------------------------------------------------------------------
+-- 1. Map a list of keymaps using vim.keymap.set
+----------------------------------------------------------------------
+
 --- Map a list of keymaps using vim.keymap.set
 --- @param mappings nairovim.KeymapDef[] List of keymap definitions
 --- @param bufnr integer|nil Buffer number to set the mapping for (optional)
+--- @usage
+--- ```
+--- local mappings = {
+---   { mode = "n", key_sequence = "<leader>ff", handler = "<cmd>Telescope find_files<CR>", opts = { noremap = true, silent = true } },
+---   { mode = "i", key_sequence = "jk", handler = "<Esc>", opts = { noremap = true } },
+--- }
+--- require("nairovim.utils.common").map(mappings)
+--- -- For buffer-local mappings:
+--- -- require("nairovim.utils.common").map(mappings, bufnr)
+--- ```
 function M.map(mappings, bufnr)
     for _, map_def in ipairs(mappings) do
         local mode = map_def.mode

--- a/v2/nvim/lua/nairovim/utils/common.lua
+++ b/v2/nvim/lua/nairovim/utils/common.lua
@@ -106,11 +106,11 @@ end
 
 --- Applies a set of highlight groups using Neovim's API, and ensures
 ---   they persist across colorscheme changes.
---- @param get_highlights fun(): nairovim.highlightspec
----   Function that returns a `nairovim.highlightspec` table, where each key is a highlight group name
+--- @param get_highlights fun(): nairovim.highlightspec Function that returns a `nairovim.highlightspec`
+---   table, where each key is a highlight group name
 ---   and each value is a table of highlight options (e.g., fg, bg, bold, italic, etc.).
---- @param highlights_groupname string
----   The name of the augroup to use for reapplying highlights on ColorScheme events.
+--- @param highlights_groupname string The name of the augroup to use for reapplying highlights
+---   on ColorScheme events.
 --- @usage
 ---   M.apply_highlights(function()
 ---     return {

--- a/v2/nvim/lua/nairovim/utils/windows.lua
+++ b/v2/nvim/lua/nairovim/utils/windows.lua
@@ -9,15 +9,15 @@ local M = {}
 ----------------------------------------------------------------------
 -- 1. with_win_backdrop: Add a semi-transparent backdrop to a window
 ----------------------------------------------------------------------
---- Adds a semi-transparent backdrop behind a target floating window.
---  This function creates a scratch buffer and opens it as a floating window
---  behind the specified target window (by filetype or buffer pattern).
---  The backdrop is styled with a dark, semi-transparent background and is
---  automatically closed when the reference buffer is closed or left.
---
---  @param target_win (string) The filetype or buffer pattern for the target window.
---  @usage
---      require('nairovim.utils.windows').with_win_backdrop('NvimTree')
+---- Adds a semi-transparent backdrop behind a target floating window.
+---  This function creates a scratch buffer and opens it as a floating window
+---  behind the specified target window (by filetype or buffer pattern).
+---  The backdrop is styled with a dark, semi-transparent background and is
+---  automatically closed when the reference buffer is closed or left.
+---
+---  @param target_win (string) The filetype or buffer pattern for the target window.
+---  @usage
+---      require('nairovim.utils.windows').with_win_backdrop('NvimTree')
 function M.with_win_backdrop(target_win)
     local blend = 60
     local default_zIndex = 40


### PR DESCRIPTION
## What does this PR do?
This PR makes small but important improvements to the configuration and documentation of the NairoVIM codebase. It updates the local leader key setting for clarity and consistency, and refines LuaDoc comments for better readability and adherence to documentation standards.

### Changes made in this PR:
- Changed `maplocalleader` from `"<space>"` to `" "` (space character) in `core/options.lua` for clarity and to match Neovim conventions.
- Improved LuaDoc formatting in `utils/common.lua`:
  - Merged and clarified parameter descriptions for the `apply_highlights` function.
  - Ensured all docstrings are prefixed with `---` as per project guidelines.
  - Added usage examples and improved line wrapping for readability.
- Added a section banner and enhanced documentation for the `map` function in `utils/common.lua`.
- Minor docstring reformatting in `utils/windows.lua` for consistency.

## Why is it needed?
- Ensures the local leader key is set in a way that is clear and consistent with Neovim best practices.
- Improves the quality and clarity of documentation, making it easier for contributors and users to understand and use utility functions.
- Adheres to updated project documentation standards (e.g., `---` prefix for docstrings).

## How have the changes been tested?
- Manual review of the configuration and documentation changes.
- Verified that the leader key and local leader key work as expected in Neovim.
- Confirmed that documentation renders correctly in supported tools and editors.

## Screenshots (if applicable)
N/A

## Checklist
- [x] Code compiles and runs as expected
- [x] Documentation is clear and follows project standards
- [x] No breaking changes introduced
- [x] Manual testing performed for key functionality
---