### PR TITLE
2025-07-28: Implement MCP Hub status component for Avante side window

### DIFF
--- a/v2/nvim/lua/nairovim/plugins/lualine.lua
+++ b/v2/nvim/lua/nairovim/plugins/lualine.lua
@@ -1,6 +1,54 @@
--- local config = lualine.get_config();
+----------------------------------------------------------------------
+-- MCP Hub Status Component (Reusable)
+----------------------------------------------------------------------
+local mcp_status_component = {
+    function()
+        -- Check if MCPHub is loaded
+        if not vim.g.loaded_mcphub then
+            return "󰐻 -"
+        end
+
+        local count = vim.g.mcphub_servers_count or 0
+        local status = vim.g.mcphub_status or "stopped"
+        local executing = vim.g.mcphub_executing
+
+        -- Show "-" when stopped
+        if status == "stopped" then
+            return "󰐻 -"
+        end
+
+        -- Show spinner when executing, starting, or restarting
+        if executing or status == "starting" or status == "restarting" then
+            local frames = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" }
+            local frame = math.floor(vim.loop.now() / 100) % #frames + 1
+            return "󰐻 " .. frames[frame]
+        end
+
+        return "󰐻 " .. count
+    end,
+    color = function()
+        if not vim.g.loaded_mcphub then
+            return { fg = "#6c7086" } -- Gray for not loaded
+        end
+
+        local status = vim.g.mcphub_status or "stopped"
+        if status == "ready" or status == "restarted" then
+            return { fg = "#50fa7b" } -- Green for connected
+        elseif status == "starting" or status == "restarting" then
+            return { fg = "#ffb86c" } -- Orange for connecting
+        else
+            return { fg = "#ff5555" } -- Red for error/stopped
+        end
+    end,
+}
+
+----------------------------------------------------------------------
+-- Extension Configurations
+----------------------------------------------------------------------
 local Blank = {
-    sections = { lualine_a = { "" } },
+    sections = {
+        lualine_a = { "" },
+    },
     filetypes = {
         "packer",
         "filetree",
@@ -12,6 +60,14 @@ local Blank = {
         "AvanteTodos",
         "AvanteSelectedFiles",
     },
+}
+
+local MCP_Info = {
+    sections = {
+        lualine_a = { "" },
+        lualine_x = { mcp_status_component },
+    },
+    filetypes = { "Avante" },
 }
 -- local Git_Branch = { sections = { lualine_b = { "branch" }, lualine_y = { "progress" } }, filetypes = { "NvimTree" } }
 return {
@@ -31,7 +87,9 @@ return {
                 },
             },
             extensions = {
-                Blank, --[[ Git_Branch  ]]
+                -- Blank, --[[ Git_Branch  ]]
+                MCP_Info,
+                Blank,
             },
             -- options = { theme = "grubbox" },
         })

--- a/v2/nvim/lua/nairovim/plugins/snacks.lua
+++ b/v2/nvim/lua/nairovim/plugins/snacks.lua
@@ -57,7 +57,7 @@ Hey there! Welcome. Enjoy a focused dev experience with NairoVIM.
                         {
                             icon = " ",
                             key = "A",
-                            desc = "Avante - (GitHub Copilot)",
+                            desc = "Avante AI - (GitHub Copilot)",
                             action = ":AvanteFocus",
                         },
                         {


### PR DESCRIPTION
## What does this PR do?

This PR enhances the lualine configuration by implementing a comprehensive MCP Hub status component and creating targeted extensions for better UI consistency. The changes improve the status line experience by providing real-time MCP server status information and creating specialized extensions for different file types.

- Implement complete MCP Hub Status Component with animated spinner, server count, and color-coded status
- Add new `MCP_Info` extension specifically for Avante AI filetypes to show MCP status
- Extract MCP status component as a reusable variable for better code organization
- Update dashboard text from "Avante - (GitHub Copilot)" to "Avante AI - (GitHub Copilot)"
- Add proper section banners for improved code structure

## Why is it needed?

The lualine configuration was missing a proper MCP Hub status indicator, making it difficult for users to understand the current state of MCP servers. This enhancement provides:

- Visual feedback on MCP server connectivity and status
- Animated indicators when servers are starting/executing
- Color-coded status (green for ready, orange for connecting, red for errors)
- Specialized status line for Avante AI workflows

## How have the changes been tested?

- MCP status component displays correctly with proper icons and colors
- Animated spinner works during server startup/execution phases
- MCP_Info extension activates properly for Avante filetypes
- Dashboard text updated successfully
- No breaking changes to existing lualine functionality
- Code follows project's Lua standards with proper section organization

## Screenshots (if applicable)

N/A - Status line changes are functional and provide visual feedback based on MCP server state

## Checklist

- [x] MCP Hub Status Component implemented with full functionality
- [x] Animated status indicators for server state changes
- [x] Color-coded visual feedback for different server states
- [x] New MCP_Info extension created for Avante filetypes
- [x] Reusable component structure for future extensions
- [x] Dashboard text updated for consistency
- [x] Proper section banners and code organization
- [x] No functional regressions in existing lualine behavior