### PR TITLE
2025-07-28: Improve MCP Status Component Theme Compatibility

### DIFF
--- a/v2/nvim/lua/nairovim/plugins/lualine.lua
+++ b/v2/nvim/lua/nairovim/plugins/lualine.lua
@@ -28,16 +28,16 @@ local mcp_status_component = {
     end,
     color = function()
         if not vim.g.loaded_mcphub then
-            return { fg = "#6c7086" } -- Gray for not loaded
+            return "Comment" -- Gray for not loaded
         end
 
         local status = vim.g.mcphub_status or "stopped"
         if status == "ready" or status == "restarted" then
-            return { fg = "#50fa7b" } -- Green for connected
+            return "DiagnosticOk" -- Green for connected
         elseif status == "starting" or status == "restarting" then
-            return { fg = "#ffb86c" } -- Orange for connecting
+            return "DiagnosticWarn" -- Orange/yellow for connecting
         else
-            return { fg = "#ff5555" } -- Red for error/stopped
+            return "DiagnosticError" -- Red for error/stopped
         end
     end,
 }


### PR DESCRIPTION
## What does this PR do?

This PR improves the MCP status component in lualine by replacing hardcoded hex colors with semantic Neovim highlight group names. This enhancement provides better theme compatibility and ensures the MCP status colors automatically adapt to the user's active colorscheme.

- Replaces hardcoded hex colors with semantic highlight group names
- Improves theme compatibility across different colorschemes
- Maintains consistent visual hierarchy with diagnostic elements
- Makes the code more maintainable and future-proof

## Why is it needed?

The previous implementation used hardcoded hex colors which:
- Did not adapt to different colorschemes
- Could create visual inconsistencies with the overall theme
- Made maintenance more difficult when updating color schemes
- Didn't follow Neovim's semantic color conventions

## How have the changes been tested?

- [x] Verified MCP status component displays correctly with semantic colors
- [x] Tested color adaptation across different colorschemes
- [x] Confirmed visual consistency with diagnostic elements
- [x] Validated that all MCP status states (ready, starting, error) show appropriate colors
- [x] No breaking changes to existing functionality

## Color Mapping Changes

| Status | Previous Color | New Highlight Group | Purpose |
|--------|----------------|--------------------|---------|
| Not Loaded | `#6c7086` (Gray) | `Comment` | Subtle, inactive state |
| Ready/Connected | `#50fa7b` (Green) | `DiagnosticOk` | Success state |
| Starting/Connecting | `#ffb86c` (Orange) | `DiagnosticWarn` | Warning/in-progress state |
| Error/Stopped | `#ff5555` (Red) | `DiagnosticError` | Error state |

## Screenshots (if applicable)

Not applicable - this is a code refactoring that maintains the same visual appearance while improving theme compatibility.

## Checklist

- [x] Replaced hardcoded hex colors with semantic highlight groups
- [x] Maintained existing MCP status functionality
- [x] Improved theme compatibility
- [x] Code follows NairoVIM conventions
- [x] Commit message includes timestamp and detailed description
- [x] GPG signed commit
- [x] No breaking changes introduced
- [x] Ready for merge into develop branch