### PR TITLE
2025-08-04: Refactor render-markdown plugin organization

### DIFF
--- a/nvim/lua/nairovim/plugins/ai/avante.lua
+++ b/nvim/lua/nairovim/plugins/ai/avante.lua
@@ -227,17 +227,5 @@ return {
                 },
             },
         },
-        {
-            -- Make sure to set this up properly if you have lazy=true
-            "MeanderingProgrammer/render-markdown.nvim",
-            opts = {
-                file_types = { "markdown", "Avante", "mcphub", "copilot-chat" },
-                code = {
-                    sign = false,
-                    language_border = "",
-                },
-            },
-            ft = { "markdown", "Avante", "mcphub", "copilot-chat" },
-        },
     },
 }

--- a/nvim/lua/nairovim/plugins/init.lua
+++ b/nvim/lua/nairovim/plugins/init.lua
@@ -80,5 +80,17 @@ return {
                 vim.fn["mkdp#util#install"]()
             end,
         },
+        {
+            -- Make sure to set this up properly if you have lazy=true
+            "MeanderingProgrammer/render-markdown.nvim",
+            opts = {
+                file_types = { "markdown", "Avante", "mcphub", "copilot-chat" },
+                code = {
+                    sign = false,
+                    language_border = "",
+                },
+            },
+            ft = { "markdown", "Avante", "mcphub", "copilot-chat" },
+        },
     },
 }


### PR DESCRIPTION
## What does this PR do?

This PR refactors the plugin organization by moving the `render-markdown.nvim` plugin configuration from the AI-specific Avante plugin file to the main plugins initialization file.

- Moves `render-markdown.nvim` configuration from `lua/nairovim/plugins/ai/avante.lua` to `lua/nairovim/plugins/init.lua`
- Improves code organization by separating markdown rendering functionality from AI-specific configurations
- Maintains the same functionality and file type support (markdown, Avante, mcphub, copilot-chat)

## Why is it needed?

- **Better Separation of Concerns**: Markdown rendering is a general functionality that shouldn't be tied specifically to the Avante AI plugin
- **Improved Maintainability**: Having general plugins in the main init file makes the codebase more organized and easier to maintain
- **Logical Organization**: Keeps AI-specific configurations in AI plugin files while general utilities remain in the main plugins file

## How have the changes been tested?

- Configuration maintains identical functionality after the move
- Plugin still supports all required file types: markdown, Avante, mcphub, copilot-chat
- No breaking changes to existing functionality
- Plugin lazy-loading behavior remains unchanged

## Screenshots (if applicable)

No UI changes - this is a code organization refactor with no visual impact.

## Checklist

- [x] Code follows project conventions and style guidelines
- [x] Plugin configuration maintains same functionality
- [x] No breaking changes introduced
- [x] File type support preserved (markdown, Avante, mcphub, copilot-chat)
- [x] Lazy loading configuration unchanged
- [x] Commit message follows project format
- [x] Changes improve code organization and maintainability