### PR TITLE
2025-08-06: Disable run_python tool in Avante AI assistant

### DIFF
--- a/nvim/lua/nairovim/plugins/ai/avante.lua
+++ b/nvim/lua/nairovim/plugins/ai/avante.lua
@@ -159,6 +159,7 @@ return {
                 "delete_dir",
                 "view",
                 "bash", -- Built-in terminal access
+                "run_python",
             },
         })
 


### PR DESCRIPTION
## What does this PR do?

This PR enhances the security configuration of the Avante AI assistant by disabling the `run_python` tool to prevent Python code execution. This change adds `run_python` to the list of disabled tools in the Avante configuration, ensuring that the AI assistant cannot execute arbitrary Python code for security and performance reasons.

- Adds `run_python` to the `disabled_tools` list in Avante configuration
- Maintains consistency with other disabled tools like `bash` for terminal access
- Improves security posture by preventing code execution capabilities

## Why is it needed?

Disabling the `run_python` tool is necessary for:
- **Security**: Prevents potential security risks from arbitrary Python code execution
- **Performance**: Avoids resource consumption from code execution
- **Consistency**: Aligns with the existing security model that already disables `bash` and other potentially dangerous tools
- **Control**: Ensures the AI assistant focuses on code analysis and suggestions rather than execution

## How have the changes been tested?

- Verified that Avante configuration loads without errors
- Confirmed that `run_python` is included in the disabled tools list
- Tested that the AI assistant cannot execute Python code snippets
- No breaking changes to existing Avante functionality

## Screenshots (if applicable)

N/A - Configuration change only

## Checklist

- [x] Code follows project coding standards
- [x] Changes have been tested locally
- [x] No breaking changes introduced
- [x] Security implications have been considered
- [x] Documentation is not required for this change
- [x] Commit message follows conventional commit format