### PR TITLE
2025-08-07: Improve lualine integration with NvimTree

### DIFF
--- a/nvim/lua/nairovim/plugins/lualine.lua
+++ b/nvim/lua/nairovim/plugins/lualine.lua
@@ -76,6 +76,7 @@ local Blank = {
         "Avante",
         "AvanteTodos",
         "AvanteSelectedFiles",
+        "NvimTree",
     },
 }
 
@@ -95,7 +96,7 @@ local Snacks_Dashboard = {
     },
     filetypes = { "snacks_dashboard" },
 }
--- local Git_Branch = { sections = { lualine_b = { "branch" }, lualine_y = { "progress" } }, filetypes = { "NvimTree" } }
+
 return {
     "nvim-lualine/lualine.nvim",
     dependencies = { "nvim-tree/nvim-web-devicons" },


### PR DESCRIPTION
## What does this PR do?

This PR improves the integration between lualine and NvimTree by adding NvimTree to the list of filetypes excluded from lualine display. This ensures that lualine doesn't interfere with NvimTree's interface, providing a cleaner file explorer experience.

- Add "NvimTree" to the excluded filetypes list in the Blank configuration
- Remove commented Git_Branch configuration line
- Improve visual consistency when using NvimTree file explorer

## Why is it needed?

When NvimTree is open, lualine was still being displayed, which could cause visual interference and inconsistent UI experience. By excluding NvimTree from lualine display, we ensure a cleaner and more focused file explorer interface.

## How have the changes been tested?

- Tested opening and closing NvimTree to verify lualine behavior
- Confirmed that lualine still works properly in regular file buffers
- Verified that the configuration doesn't break existing functionality

## Screenshots (if applicable)

N/A - UI improvement that affects lualine display behavior with NvimTree

## Checklist

- [x] Code follows project conventions and uses Lua
- [x] Changes are focused and minimal
- [x] Configuration is properly structured
- [x] No breaking changes to existing functionality
- [x] Improves user experience with NvimTree integration