### PR TITLE
2025-02-03: Fix install.sh unbound variable error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,35 @@ High-level overview of development tasks for AI agents.
 
 ---
 
+## 2025-02-02: OpenCode Windows MCP Configuration Fix
+**Goal:** Fix OpenCode global configuration loading on Windows
+
+Discovered and fixed critical issue where OpenCode was not loading global configuration (including MCP servers) on Windows. OpenCode follows XDG Base Directory specification and looks for config at `%USERPROFILE%\.config\opencode`, but the install.ps1 script was incorrectly creating symlinks at `%APPDATA%\opencode`.
+
+**Root Cause:**
+- OpenCode uses XDG paths: `~/.config/opencode/opencode.json`
+- install.ps1 was using Windows AppData: `%APPDATA%\opencode`
+- Result: Global config (model, MCPs, agents) was not loading outside project directories
+
+**Solution:**
+- Updated install.ps1 to use correct XDG path: `%USERPROFILE%\.config\opencode`
+- Set OPENCODE_CONFIG_DIR environment variable to config directory
+- Migrated existing config from AppData to .config location
+- Verified MCP servers load correctly in any directory
+
+**Verified MCP Loading:**
+- ✅ context7 (remote) - Connected
+- ✅ time (local/uvx) - Connected
+- ✅ chrome-devtools (local/npx) - Connected
+- ✅ playwright (local/npx) - Connected
+- ⚠️ github (remote) - Needs GITHUB_PERSONAL_ACCESS_TOKEN env var
+
+**Impact:** OpenCode global configuration now loads correctly on Windows, enabling MCP servers system-wide  
+**Files:** install.ps1 (modified), existing config migrated  
+**Line changes:** ~5 lines modified in install.ps1
+
+---
+
 ## 2025-11-15: Interactive Tutorial System
 **Goal:** Create comprehensive guided learning experience for new users
 

--- a/README.md
+++ b/README.md
@@ -58,12 +58,17 @@ Transform your coding experience with NairoVIM - a sophisticated Neovim configur
 #### macOS / Linux
 - **Homebrew** - Package manager ([install here](https://brew.sh/))
 - **Git** - Version control system
+- **Build Tools** - C compiler toolchain (auto-installed via script)
+  - macOS: Xcode Command Line Tools + CMake
+  - Linux: build-essential (or equivalent) + CMake
 - **Ghostty Terminal** - Modern terminal emulator (recommended, [install here](https://ghostty.org/))
   - Alternative: iTerm2, Terminal.app, or any terminal with 256-color support
 
 #### Windows
 - **Windows 10/11** - With PowerShell 5.1 or later
 - **Git for Windows** - Version control system
+- **Build Tools** - C compiler toolchain (auto-installed via script)
+  - MinGW (gcc, g++, make) + CMake
 - **Windows Terminal** - Modern terminal emulator (recommended, built-in on Windows 11)
   - Alternative: PowerShell, CMD, or any terminal with 256-color support
 - **Developer Mode** - Recommended for better symlink support (optional)

--- a/README.md
+++ b/README.md
@@ -55,11 +55,18 @@ Transform your coding experience with NairoVIM - a sophisticated Neovim configur
 
 ### System Requirements
 
-- **macOS or Linux** (Windows WSL supported)
+#### macOS / Linux
 - **Homebrew** - Package manager ([install here](https://brew.sh/))
 - **Git** - Version control system
 - **Ghostty Terminal** - Modern terminal emulator (recommended, [install here](https://ghostty.org/))
   - Alternative: iTerm2, Terminal.app, or any terminal with 256-color support
+
+#### Windows
+- **Windows 10/11** - With PowerShell 5.1 or later
+- **Git for Windows** - Version control system
+- **Windows Terminal** - Modern terminal emulator (recommended, built-in on Windows 11)
+  - Alternative: PowerShell, CMD, or any terminal with 256-color support
+- **Developer Mode** - Recommended for better symlink support (optional)
 
 ### Optional but Recommended
 
@@ -68,6 +75,8 @@ Transform your coding experience with NairoVIM - a sophisticated Neovim configur
 - **Python 3** - For certain Neovim plugins
 
 ## 🚀 Quick Installation
+
+### macOS / Linux
 
 1. **Clone the repository**:
 
@@ -100,14 +109,46 @@ Transform your coding experience with NairoVIM - a sophisticated Neovim configur
    nvim
    ```
 
-That's it! The installation script will:
+### Windows
+
+1. **Clone the repository**:
+
+   ```powershell
+   git clone https://github.com/yourusername/nairovim.git
+   cd nairovim
+   ```
+
+2. **Run the installation script** (in PowerShell as Administrator for best results):
+
+   ```powershell
+   .\install.ps1
+   ```
+
+3. **Enable Developer Mode** (recommended for better symlink support):
+   - Open **Settings** → **System** → **For developers**
+   - Enable **Developer Mode**
+
+4. **Start your development environment**:
+
+   ```powershell
+   # Launch Windows Terminal
+   wt
+   
+   # Start Neovim
+   nvim
+   ```
+
+### What Gets Installed
+
+The installation script will:
 
 - ✅ Install Neovim and essential development tools
-- ✅ Configure Ghostty with tmux-like keybindings
-- ✅ Set up tmux (optional, for legacy workflows)
-- ✅ Configure zsh with Oh My Zsh
+- ✅ Configure terminal (Ghostty on macOS/Linux, Windows Terminal on Windows)
+- ✅ Set up shell (Oh My Zsh on macOS/Linux, Oh My Posh on Windows)
+- ✅ Configure tmux (macOS/Linux only, optional for legacy workflows)
 - ✅ Install and configure 70+ Neovim plugins
 - ✅ Set up development utilities (FZF, Ripgrep, Lazygit, etc.)
+- ✅ Install OpenCode AI assistant
 - ✅ Create backups of existing configurations
 
 <details>
@@ -183,6 +224,8 @@ The tutorial covers:
 
 ### Starting a Development Session
 
+#### macOS / Linux
+
 ```bash
 # Open Ghostty terminal (recommended)
 ghostty
@@ -204,10 +247,32 @@ nvim
 <Ctrl-n>
 ```
 
-#### Ghostty Terminal Features
+#### Windows
 
-NairoVIM is optimized for Ghostty with built-in split and tab management:
+```powershell
+# Open Windows Terminal (recommended)
+wt
 
+# Open Neovim
+nvim
+
+# Start interactive tutorial (first time users)
+,tt
+
+# Or jump right in:
+# Find and open a file
+<Ctrl-s>f
+
+# Search for text across project
+<Ctrl-s>s
+
+# Open file explorer
+<Ctrl-n>
+```
+
+#### Terminal Split & Tab Management
+
+**Ghostty (macOS/Linux):**
 ```bash
 # Splits (tmux-like bindings)
 <Ctrl-b> -      # Create horizontal split
@@ -223,7 +288,23 @@ NairoVIM is optimized for Ghostty with built-in split and tab management:
 <Ctrl-b> z      # Toggle split zoom
 ```
 
-> **Note:** tmux is still supported but considered a legacy option. Ghostty provides native split/tab management with better performance.
+**Windows Terminal:**
+```powershell
+# Splits
+<Ctrl-b> -      # Create horizontal split
+<Ctrl-b> =      # Create vertical split
+<Ctrl-b> h/j/k/l # Navigate between splits
+
+# Tabs
+<Ctrl-b> c      # Create new tab
+<Ctrl-b> n/p    # Next/previous tab
+<Ctrl-b> x      # Close pane
+
+# Zoom
+<Ctrl-b> z      # Toggle pane zoom
+```
+
+> **Note:** tmux is supported on macOS/Linux but considered legacy. Modern terminals (Ghostty/Windows Terminal) provide native split/tab management with better performance.
 
 ### Essential Workflows
 
@@ -378,34 +459,39 @@ The leader key is `,` by default. Here are the most commonly used keybindings:
 
 ## 🎨 Post-Installation Setup
 
-### 1. Configure Ghostty Terminal (Recommended)
+### 1. Configure Terminal
 
-NairoVIM includes a pre-configured Ghostty setup with:
+#### macOS / Linux (Ghostty)
 
-- **TokyoNight theme** (auto-switching dark/light modes)
-- **tmux-like keybindings** for splits and tabs
-- **Optimized font rendering**
-
-The installation script automatically links the config, but you can verify:
+Ghostty is pre-configured with the repository's settings. To customize further:
 
 ```bash
-# Check Ghostty config location
-cat ~/.config/ghostty/config
+# Edit Ghostty config
+nvim ~/.config/ghostty/config
 
-# Key features:
-# - Ctrl+b prefix (tmux-style) for splits/tabs
-# - TokyoNight theme with dark/light auto-switching
-# - Font size 12 for optimal readability
+# The config includes:
+# - TokyoNight theme (dark/light auto-switch)
+# - Tmux-like keybindings (Ctrl+b prefix)
+# - Split and tab management
 ```
 
-**Ghostty vs tmux:**
+#### Windows (Windows Terminal)
 
-- ✅ **Ghostty**: Native splits/tabs, better performance, modern GPU rendering
-- ⚠️ **tmux**: Legacy option, session persistence, remote development
+Windows Terminal settings are automatically configured during installation. To customize:
 
-> **Recommendation:** Use Ghostty for local development, tmux only for remote SSH sessions.
+1. Open Windows Terminal
+2. Press `Ctrl+,` to open Settings
+3. Customize themes, fonts, and keybindings
+
+Or manually edit the JSON config:
+```powershell
+# Edit Windows Terminal settings
+notepad "$env:LOCALAPPDATA\Packages\Microsoft.WindowsTerminal_*\LocalState\settings.json"
+```
 
 ### 2. Install a Nerd Font
+
+#### macOS / Linux
 
 ```bash
 # Recommended: Hack Nerd Font
@@ -413,7 +499,21 @@ brew tap homebrew/cask-fonts
 brew install --cask font-hack-nerd-font
 ```
 
-Ghostty is pre-configured to use Nerd Font-compatible rendering.
+#### Windows
+
+Nerd Fonts are automatically installed via the PowerShell script (JetBrainsMono Nerd Font). To install additional fonts:
+
+```powershell
+# Via Scoop
+scoop install FiraCode-NF-Mono
+scoop install Hack-NF-Mono
+
+# Or download manually from https://www.nerdfonts.com/
+```
+
+To set the font in Windows Terminal:
+1. Press `Ctrl+,` → **Defaults** → **Appearance**
+2. Set **Font face** to "JetBrainsMono Nerd Font Mono"
 
 ### 3. Set Up Language Servers
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,27 @@ Transform your coding experience with NairoVIM - a sophisticated Neovim configur
 ### Optional but Recommended
 
 - **Nerd Font** - For proper icon display ([download here](https://www.nerdfonts.com/))
-- **Node.js** - For additional LSP servers and tools
-- **Python 3** - For certain Neovim plugins
+
+### Optional Development Tools
+
+These tools enable LSP servers for various languages in Neovim. The installation scripts will prompt you to install them automatically.
+
+**Windows:**
+```powershell
+scoop install nodejs go python
+```
+
+**macOS/Linux:**
+```bash
+brew install node go python
+```
+
+**What each tool enables:**
+- **Node.js (npm):** TypeScript, JavaScript, HTML, CSS, JSON LSP servers, ESLint, Prettier
+- **Go:** Go language support, gopls language server, gofumpt formatter
+- **Python:** Python language support, LSP servers, formatters, and linters
+
+These are optional during installation. If you skip them, you can install later and run `:Mason` in Neovim to install language servers.
 
 ## 🚀 Quick Installation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -272,28 +272,19 @@ NairoVIM includes 70+ carefully selected plugins organized into functional categ
 
 ## Terminal & Shell Integration
 
-NairoVIM integrates seamlessly with modern terminal emulators and shell workflows.
+NairoVIM integrates seamlessly with modern terminal emulators and shell workflows across all platforms.
 
-### Recommended Terminal: Ghostty
+### Terminal Emulators by Platform
 
-**Ghostty** is the recommended terminal for local development with NairoVIM. It offers:
+#### macOS / Linux: Ghostty (Recommended)
+
+**Ghostty** is the recommended terminal for local development on macOS and Linux. It offers:
 
 - ⚡ **GPU-accelerated rendering** - Blazing fast performance
 - 🎨 **Native transparency & blur** - Beautiful UI integration
 - ⌨️ **Built-in split/tab management** - No multiplexer needed
 - 🔧 **tmux-like keybindings** - Familiar Ctrl+b prefix workflow
 - 🎯 **Modern features** - Native ligatures, color schemes, shell integration
-
-**Key Features:**
-
-| Feature | Ghostty | tmux (Legacy) |
-|---------|---------|---------------|
-| **Performance** | GPU-accelerated, instant splits | Terminal + multiplexer overhead |
-| **UI Integration** | Native transparency/blur | Requires terminal support |
-| **Split Management** | Built-in (Ctrl+b prefix) | Requires tmux session |
-| **Tab Support** | Native tabs with animations | Windows/panes only |
-| **Configuration** | Single config file | Separate .tmux.conf |
-| **Use Case** | **Local development (recommended)** | Remote/SSH workflows only |
 
 **Ghostty Keybindings:**
 
@@ -304,19 +295,16 @@ Ctrl+b + -     # Horizontal split
 
 # Navigation
 Ctrl+b + h/j/k/l   # Navigate between splits
-Ctrl+b + [         # Navigate split focus
 
 # Tabs
 Ctrl+b + c     # New tab
 Ctrl+b + n/p   # Next/previous tab
-Ctrl+b + 0-9   # Jump to tab number
 
 # Zoom
 Ctrl+b + z     # Toggle zoom on current split
 
 # Management
 Ctrl+b + x     # Close current split/tab
-Ctrl+b + &     # Kill current window
 ```
 
 **Installation & Configuration:**
@@ -331,21 +319,91 @@ brew install --cask ghostty
 # Pre-configured with:
 # - TokyoNight theme
 # - tmux-like keybindings (Ctrl+b prefix)
-# - Hack Nerd Font
+# - Nerd Font support
 # - Shell integration
-# - 95% opacity with blur
 ```
+
+#### Windows: Windows Terminal (Recommended)
+
+**Windows Terminal** is the recommended terminal for Windows with NairoVIM. It provides:
+
+- ⚡ **GPU-accelerated rendering** - Fast, smooth performance
+- 🎨 **Modern UI** - Acrylic transparency and themes
+- ⌨️ **Built-in split/tab management** - Multiple panes and tabs
+- 🔧 **tmux-like keybindings** - Configured with Ctrl+b prefix
+- 🎯 **Windows integration** - PowerShell, CMD, and WSL support
+
+**Windows Terminal Keybindings:**
+
+```powershell
+# Splits
+Ctrl+b + -     # Horizontal split
+Ctrl+b + =     # Vertical split
+
+# Navigation
+Ctrl+b + h/j/k/l   # Navigate between panes
+
+# Tabs
+Ctrl+b + c     # New tab
+Ctrl+b + n/p   # Next/previous tab
+
+# Zoom
+Ctrl+b + z     # Toggle pane zoom
+
+# Management
+Ctrl+b + x     # Close current pane
+```
+
+**Installation & Configuration:**
+
+```powershell
+# Install via Scoop (automated by install.ps1)
+scoop install windows-terminal
+
+# Or via winget
+winget install Microsoft.WindowsTerminal
+
+# Config is auto-linked by install.ps1
+%LOCALAPPDATA%\Packages\Microsoft.WindowsTerminal_*\LocalState\settings.json
+
+# Pre-configured with:
+# - TokyoNight color scheme
+# - JetBrainsMono Nerd Font
+# - tmux-like keybindings (Ctrl+b prefix)
+# - Multiple profiles (PowerShell, CMD, WSL)
+```
+
+### Platform Comparison
+
+| Feature | Ghostty (macOS/Linux) | Windows Terminal | tmux (Legacy) |
+|---------|----------------------|------------------|---------------|
+| **Performance** | GPU-accelerated | GPU-accelerated | Terminal + multiplexer overhead |
+| **UI Integration** | Native transparency/blur | Acrylic transparency | Requires terminal support |
+| **Split Management** | Built-in (Ctrl+b) | Built-in (Ctrl+b) | Requires tmux session |
+| **Tab Support** | Native tabs | Native tabs | Windows/panes only |
+| **Configuration** | Single config file | JSON settings | Separate .tmux.conf |
+| **Platform** | macOS, Linux | Windows 10/11 | Cross-platform |
+| **Use Case** | **Local dev (macOS/Linux)** | **Local dev (Windows)** | Remote/SSH workflows |
+
+### Configuration File Locations
+
+| Platform | Config File | Location |
+|----------|------------|----------|
+| **macOS** (Ghostty) | `ghostty_config` | `~/.config/ghostty/config` |
+| **Linux** (Ghostty) | `ghostty_config` | `~/.config/ghostty/config` |
+| **Windows** (Windows Terminal) | `windows-terminal-settings.json` | `%LOCALAPPDATA%\Packages\Microsoft.WindowsTerminal_*\LocalState\settings.json` |
+| **All** (Neovim) | `nvim/` directory | macOS/Linux: `~/.config/nvim`<br>Windows: `%LOCALAPPDATA%\nvim` |
 
 ### Legacy Option: tmux
 
-> **Note:** tmux is supported but relegated to legacy/remote workflows only. For local development, use Ghostty.
+> **Note:** tmux is supported on macOS/Linux but relegated to legacy/remote workflows only. For local development, use platform-native terminals (Ghostty or Windows Terminal).
 
 **When to use tmux:**
 
 - ✅ SSH/remote development
 - ✅ Server administration
 - ✅ Session persistence requirements
-- ❌ Local development (use Ghostty instead)
+- ❌ Local development (use platform-native terminal instead)
 
 **tmux Features:**
 
@@ -354,7 +412,7 @@ brew install --cask ghostty
 - Copy mode with vi keybindings
 - Scriptable multiplexing
 
-**Installation:**
+**Installation (macOS/Linux only):**
 
 ```bash
 # Optional - only if you need tmux for remote work
@@ -365,6 +423,8 @@ git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
 ```
 
 ### Shell Configuration
+
+#### macOS / Linux (zsh)
 
 NairoVIM includes a pre-configured `.zshrc` with:
 
@@ -382,7 +442,43 @@ NairoVIM includes a pre-configured `.zshrc` with:
 ```bash
 export EDITOR="nvim"
 export VISUAL="nvim"
+export RIPGREP_CONFIG_PATH="$HOME/.ripgreprc"
 export ANTHROPIC_API_KEY="your-key"  # For Avante AI
+```
+
+#### Windows (PowerShell)
+
+NairoVIM configures PowerShell with:
+
+- **Oh My Posh** - Modern prompt theme engine
+- **TokyoNight theme** - Matching terminal colors
+- **PSReadLine** - Enhanced command-line editing
+- **Git integration** - Branch status and autocomplete
+- **fzf integration** - Fuzzy finding in PowerShell
+- **nvim** as default editor
+
+**PowerShell Profile Location:**
+
+```powershell
+# Profile auto-configured by install.ps1
+$PROFILE  # Usually: C:\Users\<username>\Documents\PowerShell\Microsoft.PowerShell_profile.ps1
+```
+
+**Environment Variables:**
+
+```powershell
+$env:EDITOR = "nvim"
+$env:VISUAL = "nvim"
+$env:RIPGREP_CONFIG_PATH = "$HOME\.ripgreprc"
+$env:ANTHROPIC_API_KEY = "your-key"  # For Avante AI
+```
+
+**Useful PowerShell Aliases:**
+
+```powershell
+# Added by install.ps1
+Set-Alias -Name vim -Value nvim
+Set-Alias -Name vi -Value nvim
 ```
 
 ---

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -432,6 +432,200 @@ git diff lazy-lock.json
 :Mason  # Check for green checkmark
 ```
 
+### Mason LSP Installation Errors
+
+#### npm/Node.js not found
+
+**Problem:** Mason fails to install LSP servers with error messages like:
+- `[ERROR] Failed to spawn process. cmd="npm", err="ENOENT: no such file or directory"`
+- `[ERROR] Installation failed for Package(name=typescript-language-server)`
+- `[ERROR] Could not find executable "npm" in PATH`
+
+**Affected packages:**
+- typescript-language-server (TypeScript/JavaScript)
+- eslint-lsp, html-lsp, css-lsp, json-lsp
+- prettierd, markdownlint, cspell
+- vscode-langservers-extracted
+
+**Solution:**
+
+**Windows:**
+```powershell
+scoop install nodejs
+```
+
+**macOS/Linux:**
+```bash
+brew install node
+```
+
+**Verify:**
+```bash
+node --version
+npm --version
+```
+
+**Retry in Neovim:**
+```vim
+:Mason
+# Navigate to failed package, press 'i' to install
+# Or use: :MasonInstall typescript-language-server
+```
+
+#### Go not found
+
+**Problem:** Mason fails with error messages like:
+- `[ERROR] Could not find executable "go" in PATH`
+- `[ERROR] Installation failed for Package(name=gopls)`
+
+**Affected packages:**
+- gopls (Go language server)
+- gofumpt (Go formatter)
+- goimports, golangci-lint
+
+**Solution:**
+
+**Windows:**
+```powershell
+scoop install go
+```
+
+**macOS/Linux:**
+```bash
+brew install go
+```
+
+**Verify:**
+```bash
+go version
+```
+
+**Retry in Neovim:**
+```vim
+:Mason
+# Navigate to gopls, press 'i' to install
+# Or use: :MasonInstall gopls
+```
+
+#### Python not found
+
+**Problem:** Mason fails with error messages like:
+- `[ERROR] Could not find executable "python" in PATH`
+- `[ERROR] Could not find executable "pip" in PATH`
+
+**Affected packages:**
+- pyright, pylsp (Python language servers)
+- black, isort, flake8 (Python formatters/linters)
+- debugpy (Python debugger)
+
+**Solution:**
+
+**Windows:**
+```powershell
+scoop install python
+```
+
+**macOS/Linux:**
+```bash
+brew install python
+```
+
+**Verify:**
+```bash
+python --version  # or python3 --version
+pip --version     # or pip3 --version
+```
+
+**Retry in Neovim:**
+```vim
+:Mason
+# Navigate to pyright, press 'i' to install
+# Or use: :MasonInstall pyright
+```
+
+#### PATH not updated after tool installation
+
+**Problem:** Tools are installed but Mason still reports "not found in PATH".
+
+**Solution:**
+
+1. **Restart your terminal** - This refreshes environment variables
+2. **Verify PATH includes tool directories:**
+
+**Windows:**
+```powershell
+# Check PATH
+$env:PATH -split ';'
+
+# Should include scoop paths like:
+# C:\Users\YourName\scoop\shims
+# C:\Users\YourName\scoop\apps\nodejs\current\bin
+```
+
+**macOS/Linux:**
+```bash
+# Check PATH
+echo $PATH | tr ':' '\n'
+
+# Should include homebrew paths like:
+# /opt/homebrew/bin (macOS Apple Silicon)
+# /usr/local/bin (macOS Intel)
+```
+
+3. **Manually add to PATH if needed:**
+
+**Windows (PowerShell profile):**
+```powershell
+# Edit profile
+notepad $PROFILE
+
+# Add scoop to PATH (if missing)
+$env:PATH = "$env:USERPROFILE\scoop\shims;" + $env:PATH
+```
+
+**macOS/Linux (shell profile):**
+```bash
+# For zsh (default on macOS)
+echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zshrc
+source ~/.zshrc
+
+# For bash
+echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+4. **Restart Neovim after fixing PATH**
+
+#### General Mason troubleshooting
+
+**Check Mason health:**
+```vim
+:checkhealth mason
+```
+
+**View Mason logs:**
+```vim
+:Mason
+# Press 'g?' to see keybindings
+# Press 'g' then 'l' to view logs for a package
+```
+
+**Clear Mason cache and reinstall:**
+```vim
+# Remove Mason data directory
+# Exit Neovim first, then:
+# Unix: rm -rf ~/.local/share/nvim/mason
+# Windows: Remove-Item -Recurse -Force ~\AppData\Local\nvim-data\mason
+
+# Restart Neovim and reinstall
+:Mason
+# Press 'I' to install all missing packages
+```
+
+**Install during setup:**
+
+If you're setting up NairoVIM for the first time, the installation scripts will prompt you to install Node.js, Go, and Python automatically. Answer "Y" to avoid these issues.
+
 ### Completions not working
 
 **Problem:** No autocomplete suggestions appearing.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -20,7 +20,9 @@ Comprehensive guide to resolving common issues with NairoVIM.
 
 ## Installation Issues
 
-### Homebrew not found
+### macOS / Linux Installation Issues
+
+#### Homebrew not found
 
 **Problem:** Installation script cannot find Homebrew.
 
@@ -35,7 +37,7 @@ echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zshrc
 source ~/.zshrc
 ```
 
-### Installation script fails
+#### Installation script fails
 
 **Problem:** Installation script encounters errors.
 
@@ -51,9 +53,107 @@ brew install --cask ghostty  # Recommended terminal
 
 # Verify installations
 nvim --version
-tmux -V
 fzf --version
 ```
+
+#### Permission denied errors
+
+**Problem:** Cannot create symlinks or write to directories.
+
+**Solution:**
+
+```bash
+# Ensure proper ownership
+sudo chown -R $(whoami) ~/.config
+sudo chown -R $(whoami) ~/.local
+
+# Run install script again
+./install.sh
+```
+
+### Windows Installation Issues
+
+#### PowerShell version too old
+
+**Problem:** PowerShell version is older than 5.1.
+
+**Solution:**
+
+```powershell
+# Check PowerShell version
+$PSVersionTable.PSVersion
+
+# Install PowerShell 7+ (recommended)
+winget install --id Microsoft.PowerShell --source winget
+
+# Or via Scoop
+scoop install pwsh
+
+# Restart terminal and use pwsh.exe
+pwsh
+```
+
+#### Scoop not found
+
+**Problem:** Installation script cannot find Scoop package manager.
+
+**Solution:**
+
+```powershell
+# Install Scoop manually
+Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+Invoke-RestMethod get.scoop.sh | Invoke-Expression
+
+# Verify installation
+scoop --version
+
+# Add required buckets
+scoop bucket add extras
+scoop bucket add nerd-fonts
+
+# Run install script again
+.\install.ps1
+```
+
+#### Developer Mode not enabled
+
+**Problem:** Symlink creation fails without Developer Mode.
+
+**Solution:**
+
+```powershell
+# Option 1: Enable Developer Mode (Recommended)
+# 1. Open Settings (Win + I)
+# 2. Go to System → For developers
+# 3. Enable "Developer Mode"
+# 4. Restart PowerShell and run install.ps1 again
+
+# Option 2: Run PowerShell as Administrator
+# Right-click PowerShell → "Run as Administrator"
+# Then run: .\install.ps1
+```
+
+#### Git not found on Windows
+
+**Problem:** Git is not installed or not in PATH.
+
+**Solution:**
+
+```powershell
+# Install Git via Scoop
+scoop install git
+
+# Or install Git for Windows
+winget install Git.Git
+
+# Verify installation
+git --version
+
+# Add to PATH if needed
+$env:Path += ";C:\Program Files\Git\bin"
+```
+
+### Common to All Platforms
 
 ### Neovim version too old
 
@@ -757,7 +857,9 @@ vim.keymap.set("n", "<key>", callback, { noremap = true })
 
 ## Terminal and Shell Issues
 
-### Ghostty terminal issues
+### macOS / Linux Terminal Issues
+
+#### Ghostty terminal issues
 
 **Problem:** Ghostty terminal not working as expected with Neovim.
 
@@ -787,7 +889,7 @@ echo $TERM  # Should be xterm-256color
 # Ctrl+b + [ (navigate panes)
 ```
 
-### Ghostty config not loaded
+#### Ghostty config not loaded
 
 **Problem:** Custom Ghostty configuration not applying.
 
@@ -810,7 +912,7 @@ ghostty --config-check
 echo $GHOSTTY_RESOURCES_DIR
 ```
 
-### Ghostty splits not working
+#### Ghostty splits not working
 
 **Problem:** Keybindings for splits/tabs don't work.
 
@@ -835,9 +937,210 @@ grep "keybind" ~/.config/ghostty/config
 # Cmd + t (new tab)
 ```
 
-### Tmux integration not working (Legacy)
+### Windows Terminal Issues
 
-> **Note:** tmux is supported for legacy/remote workflows only. For local development, Ghostty terminal is recommended.
+#### Windows Terminal not installed
+
+**Problem:** Windows Terminal is not installed or not found.
+
+**Solution:**
+
+```powershell
+# Check if Windows Terminal is installed
+winget list --id Microsoft.WindowsTerminal
+
+# Install via winget
+winget install Microsoft.WindowsTerminal
+
+# Or install via Scoop
+scoop install windows-terminal
+
+# Or install from Microsoft Store
+# Open Microsoft Store and search "Windows Terminal"
+```
+
+#### Windows Terminal settings not applying
+
+**Problem:** Custom Windows Terminal configuration not loading.
+
+**Solution:**
+
+```powershell
+# Check settings file location
+Get-ChildItem "$env:LOCALAPPDATA\Packages\Microsoft.WindowsTerminal*\LocalState\settings.json"
+
+# If symlink is broken, recreate it
+# First, backup existing settings
+Copy-Item "$env:LOCALAPPDATA\Packages\Microsoft.WindowsTerminal_*\LocalState\settings.json" `
+  "$env:LOCALAPPDATA\Packages\Microsoft.WindowsTerminal_*\LocalState\settings.json.backup"
+
+# Create symlink (requires Developer Mode or admin)
+$wtDir = (Get-ChildItem "$env:LOCALAPPDATA\Packages" -Filter "Microsoft.WindowsTerminal*")[0].FullName
+New-Item -ItemType SymbolicLink `
+  -Path "$wtDir\LocalState\settings.json" `
+  -Target "$(Get-Location)\windows-terminal-settings.json" -Force
+
+# Reload Windows Terminal (Ctrl+Shift+T to open new tab)
+```
+
+#### Windows Terminal keybindings not working
+
+**Problem:** Ctrl+b prefix keybindings don't work in Windows Terminal.
+
+**Solution:**
+
+```powershell
+# Check Windows Terminal settings
+# Press Ctrl+, to open Settings
+
+# Verify keybindings in settings.json
+# Look for "actions" array with "ctrl+b|..." patterns
+
+# Common fixes:
+# 1. Ensure "useAcrylicInTabRow" is false for better performance
+# 2. Check for conflicting keybindings in the actions section
+# 3. Restart Windows Terminal completely (close all windows)
+
+# Test keybindings manually:
+# Ctrl+b then - (horizontal split)
+# Ctrl+b then = (vertical split)
+# Ctrl+b then h/j/k/l (navigate panes)
+```
+
+#### Symlink creation fails on Windows
+
+**Problem:** Installation script fails to create symlinks.
+
+**Solution:**
+
+```powershell
+# Option 1: Enable Developer Mode (Recommended)
+# 1. Open Settings → System → For developers
+# 2. Enable "Developer Mode"
+# 3. Restart PowerShell
+# 4. Run install.ps1 again
+
+# Option 2: Run as Administrator
+# Right-click PowerShell → "Run as Administrator"
+# Then run: .\install.ps1
+
+# Option 3: Use hard links or junctions instead
+# Edit install.ps1 to use:
+cmd /c mklink /J "target" "source"  # For directories
+cmd /c mklink /H "target" "source"  # For files
+
+# Verify symlinks created successfully
+Get-Item "$env:LOCALAPPDATA\nvim" | Select-Object LinkType, Target
+```
+
+#### PowerShell execution policy error
+
+**Problem:** Cannot run install.ps1 due to execution policy.
+
+**Solution:**
+
+```powershell
+# Check current execution policy
+Get-ExecutionPolicy
+
+# Set execution policy for current user (recommended)
+Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+
+# Or bypass for single execution
+PowerShell -ExecutionPolicy Bypass -File .\install.ps1
+
+# If still blocked, unblock the script
+Unblock-File .\install.ps1
+```
+
+#### Scoop installation fails
+
+**Problem:** Scoop package manager fails to install.
+
+**Solution:**
+
+```powershell
+# Ensure prerequisites
+# 1. PowerShell 5.1 or later
+$PSVersionTable.PSVersion
+
+# 2. Set execution policy
+Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+
+# 3. Manual Scoop installation
+Invoke-RestMethod get.scoop.sh | Invoke-Expression
+
+# 4. Add buckets manually if needed
+scoop bucket add extras
+scoop bucket add nerd-fonts
+
+# 5. Verify Scoop installation
+scoop --version
+scoop list
+```
+
+#### Neovim config path issues on Windows
+
+**Problem:** Neovim cannot find configuration at `%LOCALAPPDATA%\nvim`.
+
+**Solution:**
+
+```powershell
+# Check Neovim config path
+nvim --version
+# Look for "init.lua or init.vim locations"
+
+# Verify symlink exists and is valid
+Get-Item "$env:LOCALAPPDATA\nvim"
+
+# If symlink is broken, recreate it
+Remove-Item "$env:LOCALAPPDATA\nvim" -Force -ErrorAction SilentlyContinue
+New-Item -ItemType SymbolicLink -Path "$env:LOCALAPPDATA\nvim" -Target "$(Get-Location)\nvim"
+
+# Alternative: Use $env:XDG_CONFIG_HOME
+$env:XDG_CONFIG_HOME = "$env:USERPROFILE\.config"
+[Environment]::SetEnvironmentVariable("XDG_CONFIG_HOME", "$env:USERPROFILE\.config", "User")
+
+# Then create symlink at ~/.config/nvim
+New-Item -ItemType Directory -Path "$env:USERPROFILE\.config" -Force
+New-Item -ItemType SymbolicLink -Path "$env:USERPROFILE\.config\nvim" -Target "$(Get-Location)\nvim"
+```
+
+#### Oh My Posh theme not loading
+
+**Problem:** Oh My Posh prompt theme not showing in PowerShell.
+
+**Solution:**
+
+```powershell
+# Check Oh My Posh installation
+oh-my-posh --version
+
+# Reinstall if missing
+scoop install oh-my-posh
+
+# Verify PowerShell profile exists
+Test-Path $PROFILE
+
+# Check Oh My Posh init command in profile
+Get-Content $PROFILE | Select-String "oh-my-posh"
+
+# Manually add to profile if missing
+$initCommand = @"
+oh-my-posh init pwsh --config "`$env:POSH_THEMES_PATH\tokyonight_storm.omp.json" | Invoke-Expression
+"@
+Add-Content $PROFILE $initCommand
+
+# Reload profile
+. $PROFILE
+
+# List available themes
+Get-ChildItem "$env:POSH_THEMES_PATH" | Select-Object Name
+```
+
+### Tmux integration not working (Legacy - macOS/Linux only)
+
+> **Note:** tmux is supported for legacy/remote workflows only. For local development, use Ghostty (macOS/Linux) or Windows Terminal (Windows).
 
 **Problem:** Tmux features not working with Neovim.
 
@@ -863,7 +1166,9 @@ cat ~/.tmux.conf
 echo $TERM  # Should be screen-256color or tmux-256color
 ```
 
-### Shell completions missing
+### Shell Configuration Issues
+
+#### Shell completions missing (macOS/Linux)
 
 **Problem:** Tab completions don't work in shell.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -153,6 +153,123 @@ git --version
 $env:Path += ";C:\Program Files\Git\bin"
 ```
 
+#### C compiler not found (Windows)
+
+**Problem:** Neovim plugins fail to build with errors like "No C compiler found" or "gcc/make not found".
+
+**Affected Plugins:**
+- `telescope-fzf-native.nvim` - Requires make/cmake
+- `nvim-treesitter` - Requires C compiler for parser compilation
+- `CopilotChat.nvim` - Requires make for tiktoken build
+
+**Solution:**
+
+```powershell
+# Automatic (recommended) - Re-run install script
+.\install.ps1
+
+# Manual installation via Scoop
+scoop install mingw cmake
+
+# Verify installation
+gcc --version
+make --version
+cmake --version
+
+# Restart terminal for PATH changes
+```
+
+**Rebuild plugins in Neovim:**
+
+```vim
+" Force rebuild telescope-fzf-native
+:Lazy build telescope-fzf-native.nvim
+
+" Update all treesitter parsers
+:TSUpdate all
+
+" Rebuild CopilotChat
+:Lazy build CopilotChat.nvim
+
+" Check health status
+:checkhealth telescope
+:checkhealth treesitter
+```
+
+**Alternative: Visual Studio Build Tools (Advanced)**
+
+If MinGW doesn't work, install Visual Studio Build Tools:
+
+```powershell
+# Install Visual Studio Build Tools (6GB download)
+winget install Microsoft.VisualStudio.2022.BuildTools
+
+# During installation, select:
+# - Desktop development with C++
+# - Windows 10/11 SDK
+```
+
+#### C compiler not found (macOS/Linux)
+
+**Problem:** Build tools are missing or incomplete.
+
+**Solution (macOS):**
+
+```bash
+# Install Xcode Command Line Tools
+xcode-select --install
+
+# Or install full Xcode from App Store
+# Then enable command line tools:
+sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+
+# Verify installation
+gcc --version
+make --version
+cmake --version
+
+# If cmake missing, install via Homebrew
+brew install cmake
+```
+
+**Solution (Linux - Debian/Ubuntu):**
+
+```bash
+# Install build-essential
+sudo apt-get update
+sudo apt-get install -y build-essential cmake
+
+# Verify installation
+gcc --version
+make --version
+cmake --version
+```
+
+**Solution (Linux - Fedora/RHEL):**
+
+```bash
+# Install Development Tools
+sudo dnf groupinstall -y "Development Tools"
+sudo dnf install -y cmake
+
+# Verify installation
+gcc --version
+make --version
+cmake --version
+```
+
+**Solution (Linux - Arch):**
+
+```bash
+# Install base-devel
+sudo pacman -S --noconfirm base-devel cmake
+
+# Verify installation
+gcc --version
+make --version
+cmake --version
+```
+
 ### Common to All Platforms
 
 ### Neovim version too old

--- a/install.ps1
+++ b/install.ps1
@@ -725,11 +725,11 @@ function Install-OpenCode {
         Print-Info "OpenCode is already installed, skipping..."
     }
     
-    # Setup OpenCode configuration
-    Print-Step "Setting up OpenCode configuration" "$env:APPDATA\opencode"
+    # Setup OpenCode configuration (XDG Base Directory compliant)
+    Print-Step "Setting up OpenCode configuration" "~\.config\opencode"
     
     $opencodeConfigSource = Join-Path $PSScriptRoot "opencode_global_config"
-    $opencodeConfigTarget = Join-Path $env:APPDATA "opencode"
+    $opencodeConfigTarget = Join-Path $env:USERPROFILE ".config\opencode"
     
     if (-not (Test-Path $opencodeConfigSource)) {
         Print-Error "OpenCode configuration source not found at $opencodeConfigSource"
@@ -865,6 +865,22 @@ function Install-OpenCode {
         } else {
             New-Symlink -Source $item.FullName -Target $itemTarget -Name "OpenCode $itemName"
         }
+    }
+    
+    # Set OPENCODE_CONFIG_DIR environment variable
+    Print-Step "Setting OPENCODE_CONFIG_DIR environment variable" "for MCP server loading"
+    [Environment]::SetEnvironmentVariable("OPENCODE_CONFIG_DIR", $opencodeConfigTarget, "User")
+    Print-Success "OPENCODE_CONFIG_DIR set to: $opencodeConfigTarget"
+    
+    # Add to PowerShell profile
+    if (-not (Test-Path $PROFILE)) {
+        New-Item -ItemType File -Path $PROFILE -Force | Out-Null
+    }
+    
+    $profileContent = Get-Content $PROFILE -Raw -ErrorAction SilentlyContinue
+    if ($profileContent -notmatch "OPENCODE_CONFIG_DIR") {
+        Add-Content $PROFILE "`n# OpenCode Configuration`n`$env:OPENCODE_CONFIG_DIR = '$opencodeConfigTarget'"
+        Print-Info "Added OPENCODE_CONFIG_DIR to PowerShell profile"
     }
     
     # Show backup session summary

--- a/install.ps1
+++ b/install.ps1
@@ -878,10 +878,10 @@ function Main {
 
 trap {
     Write-Host ""
-    Print-Error "Installation interrupted or failed: $_"
-    Write-ColorOutput "Please check the error messages above and try again." -Color "Yellow"
+    Write-Host "$([char]0x2717) Error - Installation interrupted or failed: $_" -ForegroundColor Red
+    Write-Host "Please check the error messages above and try again." -ForegroundColor Yellow
     Write-Host ""
-    Write-ColorOutput "Need help? Check the documentation or open an issue on GitHub." -Color "Blue"
+    Write-Host "Need help? Check the documentation or open an issue on GitHub." -ForegroundColor Blue
     exit 1
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -278,6 +278,67 @@ function Install-WithScoop {
 # MAIN INSTALLATION FUNCTIONS
 # ======================================================================
 
+function Install-BuildTools {
+    Print-Section "$($Symbols.Gear) Installing Build Tools"
+    
+    Print-Info "Installing C compiler toolchain for Neovim plugin compilation..."
+    Print-Info "This enables: telescope-fzf-native, nvim-treesitter, CopilotChat"
+    
+    # Install MinGW (provides gcc, g++, make)
+    Install-WithScoop -Package "mingw" -DisplayName "MinGW (GCC compiler)"
+    
+    # Install CMake (build system)
+    Install-WithScoop -Package "cmake" -DisplayName "CMake"
+    
+    # Verify installations
+    Print-Step "Verifying build tools installation"
+    
+    $buildToolsReady = $true
+    
+    if (Test-Command "gcc") {
+        try {
+            $gccOutput = gcc --version 2>&1 | Select-Object -First 1
+            $gccVersion = if ($gccOutput -match '(\d+\.\d+\.\d+)') { $matches[1] } else { "unknown" }
+            Print-Success "GCC compiler ready (v$gccVersion)"
+        } catch {
+            Print-Success "GCC compiler ready"
+        }
+    } else {
+        Print-Warning "GCC not found in PATH"
+        $buildToolsReady = $false
+    }
+    
+    if (Test-Command "make") {
+        Print-Success "GNU Make ready"
+    } else {
+        Print-Warning "Make not found in PATH"
+        $buildToolsReady = $false
+    }
+    
+    if (Test-Command "cmake") {
+        try {
+            $cmakeOutput = cmake --version 2>&1 | Select-Object -First 1
+            $cmakeVersion = if ($cmakeOutput -match '(\d+\.\d+\.\d+)') { $matches[1] } else { "unknown" }
+            Print-Success "CMake ready (v$cmakeVersion)"
+        } catch {
+            Print-Success "CMake ready"
+        }
+    } else {
+        Print-Warning "CMake not found in PATH"
+        $buildToolsReady = $false
+    }
+    
+    if ($buildToolsReady) {
+        Print-Success "Build tools configured successfully"
+    } else {
+        Print-Warning "Some build tools may require terminal restart to be available"
+        Print-Info "Close and reopen your terminal, then run: .\install.ps1"
+    }
+    
+    Write-Host ""
+    Print-Success "Build tools installation complete!"
+}
+
 function Install-Dotfiles {
     Print-Section "$($Symbols.Link) Linking Dotfiles"
     
@@ -728,6 +789,7 @@ function Print-InstallationSummary {
     Write-ColorOutput "╚══════════════════════════════════════════════════════════════════════════════════════╝" -Color "Magenta"
     Write-Host ""
     Write-ColorOutput "📋 Installation Summary:" -Color "Cyan"
+    Write-Host "$($Symbols.CheckMark) Build tools installed (MinGW, CMake)"
     Write-Host "$($Symbols.CheckMark) Dotfiles linked (.ripgreprc, scooter config)"
     Write-Host "$($Symbols.CheckMark) Neovim installed and configured"
     Write-Host "$($Symbols.CheckMark) Windows Terminal installed and configured"
@@ -787,6 +849,7 @@ function Main {
     
     # Execute installation steps
     Install-Scoop
+    Install-BuildTools
     Install-Dotfiles
     Install-Neovim
     Install-WindowsTerminal

--- a/install.ps1
+++ b/install.ps1
@@ -70,9 +70,9 @@ function Print-Header {
     param([string]$Title)
     
     Write-Host ""
-    $topBorder = [char]0x2554 + ([char]0x2550 * 86) + [char]0x2557
+    $topBorder = [char]0x2554 + ([string][char]0x2550 * 86) + [char]0x2557
     $titleLine = [char]0x2551 + "  $Title"
-    $bottomBorder = [char]0x255A + ([char]0x2550 * 86) + [char]0x255D
+    $bottomBorder = [char]0x255A + ([string][char]0x2550 * 86) + [char]0x255D
     
     Write-ColorOutput $topBorder -Color "Cyan"
     Write-ColorOutput $titleLine -Color "Magenta"
@@ -789,10 +789,10 @@ function Install-OpenCode {
 
 function Print-InstallationSummary {
     Write-Host ""
-    $topBorder = [char]0x2554 + ([char]0x2550 * 86) + [char]0x2557
+    $topBorder = [char]0x2554 + ([string][char]0x2550 * 86) + [char]0x2557
     $emoji = [System.Char]::ConvertFromUtf32(0x1F389)
     $titleLine = [char]0x2551 + "  $emoji INSTALLATION COMPLETE! $emoji"
-    $bottomBorder = [char]0x255A + ([char]0x2550 * 86) + [char]0x255D
+    $bottomBorder = [char]0x255A + ([string][char]0x2550 * 86) + [char]0x255D
     
     Write-ColorOutput $topBorder -Color "Magenta"
     Write-ColorOutput $titleLine -Color "Green"

--- a/install.ps1
+++ b/install.ps1
@@ -344,6 +344,101 @@ function Install-BuildTools {
     Print-Success "Build tools installation complete!"
 }
 
+function Install-DevelopmentTools {
+    Print-Section "$($Symbols.Package) Installing Development Tools (Optional)"
+    
+    Print-Info "Development tools enable LSP servers for various languages in Neovim"
+    Print-Info "Includes: Node.js (npm), Go, Python"
+    Write-Host ""
+    
+    # Prompt user
+    $response = Read-Host "Install development tools? [Y/n]"
+    if ($response -match '^[Nn]') {
+        Print-Info "Skipping development tools installation"
+        Print-Info "You can install later with: scoop install nodejs go python"
+        return
+    }
+    
+    Write-Host ""
+    Print-Step "Installing development tools" "Node.js, Go, Python"
+    
+    # Install Node.js (includes npm)
+    Install-WithScoop -Package "nodejs" -DisplayName "Node.js (npm)"
+    
+    # Install Go
+    Install-WithScoop -Package "go" -DisplayName "Go (golang)"
+    
+    # Install Python
+    Install-WithScoop -Package "python" -DisplayName "Python"
+    
+    # Verify installations
+    Print-Step "Verifying development tools installation"
+    
+    $toolsReady = $true
+    
+    if (Test-Command "node") {
+        try {
+            $nodeOutput = node --version 2>&1
+            $nodeVersion = if ($nodeOutput -match 'v(\d+\.\d+\.\d+)') { $matches[1] } else { "unknown" }
+            Print-Success "Node.js ready (v$nodeVersion)"
+            
+            if (Test-Command "npm") {
+                $npmOutput = npm --version 2>&1
+                Print-Success "npm ready (v$npmOutput)"
+            }
+        } catch {
+            Print-Success "Node.js installed"
+        }
+    } else {
+        Print-Warning "Node.js not found in PATH"
+        $toolsReady = $false
+    }
+    
+    if (Test-Command "go") {
+        try {
+            $goOutput = go version 2>&1
+            $goVersion = if ($goOutput -match 'go(\d+\.\d+\.\d+)') { $matches[1] } else { "unknown" }
+            Print-Success "Go ready (v$goVersion)"
+        } catch {
+            Print-Success "Go installed"
+        }
+    } else {
+        Print-Warning "Go not found in PATH"
+        $toolsReady = $false
+    }
+    
+    if (Test-Command "python") {
+        try {
+            $pythonOutput = python --version 2>&1
+            $pythonVersion = if ($pythonOutput -match 'Python (\d+\.\d+\.\d+)') { $matches[1] } else { "unknown" }
+            Print-Success "Python ready (v$pythonVersion)"
+            
+            if (Test-Command "pip") {
+                Print-Success "pip ready"
+            }
+        } catch {
+            Print-Success "Python installed"
+        }
+    } else {
+        Print-Warning "Python not found in PATH"
+        $toolsReady = $false
+    }
+    
+    if ($toolsReady) {
+        Print-Success "Development tools configured successfully"
+        Print-Info "Neovim Mason can now install LSP servers for:"
+        Write-Host "  $([char]0x2022) TypeScript, JavaScript, HTML, CSS, JSON (requires Node.js)"
+        Write-Host "  $([char]0x2022) Go language support (requires Go)"
+        Write-Host "  $([char]0x2022) Python language support (requires Python)"
+    } else {
+        Print-Warning "Some tools may require terminal restart to be available"
+        Print-Info "Close and reopen your terminal, then run: .\install.ps1"
+    }
+    
+    Write-Host ""
+    Print-Success "Development tools installation complete!"
+}
+
 function Install-Dotfiles {
     Print-Section "$($Symbols.Link) Linking Dotfiles"
     
@@ -800,6 +895,7 @@ function Print-InstallationSummary {
     Write-Host ""
     Write-ColorOutput "$([System.Char]::ConvertFromUtf32(0x1F4CB)) Installation Summary:" -Color "Cyan"
     Write-Host "$($Symbols.CheckMark) Build tools installed (MinGW, CMake)"
+    Write-Host "$($Symbols.CheckMark) Development tools installed (Node.js, Go, Python) [optional]"
     Write-Host "$($Symbols.CheckMark) Dotfiles linked (.ripgreprc, scooter config)"
     Write-Host "$($Symbols.CheckMark) Neovim installed and configured"
     Write-Host "$($Symbols.CheckMark) Windows Terminal installed and configured"
@@ -862,6 +958,7 @@ function Main {
     # Execute installation steps
     Install-Scoop
     Install-BuildTools
+    Install-DevelopmentTools
     Install-Dotfiles
     Install-Neovim
     Install-WindowsTerminal

--- a/install.ps1
+++ b/install.ps1
@@ -45,9 +45,9 @@ $Script:Symbols = @{
     ArrowRight = [char]0x2192  # →
     Star       = [char]0x2605  # ★
     Gear       = [char]0x2699  # ⚙
-    Rocket     = [char]0x1F680 # 🚀
-    Package    = [char]0x1F4E6 # 📦
-    Link       = [char]0x1F517 # 🔗
+    Rocket     = [System.Char]::ConvertFromUtf32(0x1F680) # 🚀
+    Package    = [System.Char]::ConvertFromUtf32(0x1F4E6) # 📦
+    Link       = [System.Char]::ConvertFromUtf32(0x1F517) # 🔗
     Sparkles   = [char]0x2728  # ✨
     Hourglass  = [char]0x23F3  # ⏳
     Warning    = [char]0x26A0  # ⚠
@@ -790,14 +790,15 @@ function Install-OpenCode {
 function Print-InstallationSummary {
     Write-Host ""
     $topBorder = [char]0x2554 + ([char]0x2550 * 86) + [char]0x2557
-    $titleLine = [char]0x2551 + "  " + [char]0x1F389 + " INSTALLATION COMPLETE! " + [char]0x1F389
+    $emoji = [System.Char]::ConvertFromUtf32(0x1F389)
+    $titleLine = [char]0x2551 + "  $emoji INSTALLATION COMPLETE! $emoji"
     $bottomBorder = [char]0x255A + ([char]0x2550 * 86) + [char]0x255D
     
     Write-ColorOutput $topBorder -Color "Magenta"
     Write-ColorOutput $titleLine -Color "Green"
     Write-ColorOutput $bottomBorder -Color "Magenta"
     Write-Host ""
-    Write-ColorOutput "$([char]0x1F4CB) Installation Summary:" -Color "Cyan"
+    Write-ColorOutput "$([System.Char]::ConvertFromUtf32(0x1F4CB)) Installation Summary:" -Color "Cyan"
     Write-Host "$($Symbols.CheckMark) Build tools installed (MinGW, CMake)"
     Write-Host "$($Symbols.CheckMark) Dotfiles linked (.ripgreprc, scooter config)"
     Write-Host "$($Symbols.CheckMark) Neovim installed and configured"
@@ -808,19 +809,20 @@ function Print-InstallationSummary {
     Write-Host "$($Symbols.CheckMark) Lazygit installed and configured"
     Write-Host "$($Symbols.CheckMark) OpenCode installed and configured"
     Write-Host ""
-    Write-ColorOutput "$([char]0x1F680) Next Steps:" -Color "Yellow"
+    Write-ColorOutput "$([System.Char]::ConvertFromUtf32(0x1F680)) Next Steps:" -Color "Yellow"
     Write-Host "1. Restart your PowerShell session or run: . `$PROFILE"
     Write-Host "2. Launch Windows Terminal (search 'Windows Terminal' in Start Menu)"
     Write-Host "3. Run 'nvim' to start Neovim and let plugins install"
     Write-Host "4. In Neovim, run ':Tutorial' to start the interactive tutorial"
     Write-Host "5. Configure your language servers as needed"
     Write-Host ""
-    Write-ColorOutput "$([char]0x1F4A1) Useful Tips:" -Color "Blue"
+    Write-ColorOutput "$([System.Char]::ConvertFromUtf32(0x1F4A1)) Useful Tips:" -Color "Blue"
     Write-Host "$([char]0x2022) Enable Developer Mode in Windows Settings for better symlink support"
     Write-Host "$([char]0x2022) Set Windows Terminal as your default terminal in Windows Settings"
     Write-Host "$([char]0x2022) Install PowerShell 7+ for better experience: scoop install pwsh"
     Write-Host ""
-    Write-ColorOutput "$([char]0x1F38A) Happy coding with NairoVIM on Windows! $([char]0x1F38A)" -Color "Green"
+    $confetti = [System.Char]::ConvertFromUtf32(0x1F38A)
+    Write-ColorOutput "$confetti Happy coding with NairoVIM on Windows! $confetti" -Color "Green"
     Write-Host ""
 }
 
@@ -830,7 +832,8 @@ function Print-InstallationSummary {
 
 function Main {
     # Print welcome header
-    Print-Header "$([char]0x1F680) NairoVIM Installation Script for Windows $([char]0x1F680)"
+    $rocket = [System.Char]::ConvertFromUtf32(0x1F680)
+    Print-Header "$rocket NairoVIM Installation Script for Windows $rocket"
     
     Write-ColorOutput "Welcome to the NairoVIM installation script for Windows!" -Color "Cyan"
     Write-Host "$($Colors.Dim)This script will install and configure your complete development environment.$($Colors.Reset)"
@@ -854,7 +857,7 @@ function Main {
     
     # Start installation process
     Write-Host ""
-    Write-ColorOutput "$([char]0x1F527) Starting installation process..." -Color "Cyan"
+    Write-ColorOutput "$([System.Char]::ConvertFromUtf32(0x1F527)) Starting installation process..." -Color "Cyan"
     
     # Execute installation steps
     Install-Scoop

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,821 @@
+#Requires -Version 5.1
+
+<#
+.SYNOPSIS
+    NairoVIM Installation Script for Windows
+
+.DESCRIPTION
+    Enhanced installation script for NairoVIM on Windows. Installs Neovim,
+    Windows Terminal, Oh My Posh, CLI tools, and configures your complete
+    development environment using Scoop package manager.
+
+.NOTES
+    Version:        1.0.0
+    Author:         NairoVIM Team
+    Requires:       PowerShell 5.1+, Windows 10/11
+#>
+
+# ======================================================================
+# ERROR HANDLING & CONFIGURATION
+# ======================================================================
+
+$ErrorActionPreference = "Stop"
+$PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
+
+# ======================================================================
+# COLOR DEFINITIONS & STYLING
+# ======================================================================
+
+$Script:Colors = @{
+    Reset   = "`e[0m"
+    Red     = "`e[31m"
+    Green   = "`e[32m"
+    Yellow  = "`e[33m"
+    Blue    = "`e[34m"
+    Magenta = "`e[35m"
+    Cyan    = "`e[36m"
+    Bold    = "`e[1m"
+    Dim     = "`e[2m"
+}
+
+# Enhanced symbols with Unicode support
+$Script:Symbols = @{
+    CheckMark  = "✓"
+    CrossMark  = "✗"
+    ArrowRight = "→"
+    Star       = "★"
+    Gear       = "⚙"
+    Rocket     = "🚀"
+    Package    = "📦"
+    Link       = "🔗"
+    Sparkles   = "✨"
+    Hourglass  = "⏳"
+    Warning    = "⚠"
+    Info       = "ℹ"
+}
+
+# ======================================================================
+# UTILITY FUNCTIONS
+# ======================================================================
+
+function Write-ColorOutput {
+    param(
+        [string]$Message,
+        [string]$Color = "Reset"
+    )
+    Write-Host "$($Colors[$Color])$Message$($Colors.Reset)"
+}
+
+function Print-Header {
+    param([string]$Title)
+    
+    Write-Host ""
+    Write-ColorOutput "╔══════════════════════════════════════════════════════════════════════════════════════╗" -Color "Cyan"
+    Write-ColorOutput "║  $Title" -Color "Magenta"
+    Write-ColorOutput "╚══════════════════════════════════════════════════════════════════════════════════════╝" -Color "Cyan"
+    Write-Host ""
+}
+
+function Print-Section {
+    param([string]$Title)
+    
+    Write-Host ""
+    Write-ColorOutput "▓▓▓ $Title ▓▓▓" -Color "Blue"
+    Write-Host ""
+}
+
+function Print-Step {
+    param(
+        [string]$Message,
+        [string]$Detail = ""
+    )
+    
+    $output = "$($Symbols.Hourglass) $($Colors.Bold)$Message$($Colors.Reset)"
+    if ($Detail) {
+        $output += " $($Colors.Dim)$Detail$($Colors.Reset)"
+    }
+    Write-Host $output
+}
+
+function Print-Success {
+    param([string]$Message)
+    Write-ColorOutput "$($Symbols.CheckMark) Done - $Message" -Color "Green"
+}
+
+function Print-Error {
+    param([string]$Message)
+    Write-ColorOutput "$($Symbols.CrossMark) Error - $Message" -Color "Red"
+}
+
+function Print-Warning {
+    param([string]$Message)
+    Write-ColorOutput "$($Symbols.Warning) Warning - $Message" -Color "Yellow"
+}
+
+function Print-Info {
+    param([string]$Message)
+    Write-ColorOutput "$($Symbols.Info) Info - $Message" -Color "Blue"
+}
+
+function Test-Command {
+    param([string]$CommandName)
+    
+    $null -ne (Get-Command $CommandName -ErrorAction SilentlyContinue)
+}
+
+function Test-AdminPrivileges {
+    $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+    return $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function New-Symlink {
+    param(
+        [string]$Source,
+        [string]$Target,
+        [string]$Name
+    )
+    
+    $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+    
+    # Check if target is a symlink
+    if (Test-Path $Target -PathType Any) {
+        $item = Get-Item $Target -Force
+        
+        if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+            # It's a symlink
+            if (-not (Test-Path $Target)) {
+                Print-Warning "$Name is a dangling symlink (target missing), removing..."
+            } else {
+                Print-Info "$Name symlink already exists, updating..."
+            }
+            Remove-Item $Target -Force
+        } elseif ($item.PSIsContainer) {
+            # It's a directory
+            $backupPath = "${Target}.backup.${timestamp}"
+            Print-Warning "$Name directory exists, backing up to $backupPath"
+            Move-Item $Target $backupPath -Force
+            Print-Success "Backup created: $backupPath"
+        } else {
+            # It's a regular file
+            $backupPath = "${Target}.backup.${timestamp}"
+            Print-Warning "$Name file exists, backing up to $backupPath"
+            Move-Item $Target $backupPath -Force
+            Print-Success "Backup created: $backupPath"
+        }
+    }
+    
+    # Create parent directory if it doesn't exist
+    $parentDir = Split-Path $Target -Parent
+    if (-not (Test-Path $parentDir)) {
+        New-Item -ItemType Directory -Path $parentDir -Force | Out-Null
+    }
+    
+    # Create symlink
+    try {
+        New-Item -ItemType SymbolicLink -Path $Target -Value $Source -Force | Out-Null
+        Write-Host "    $($Colors.Green)$($Symbols.Link) $Name$($Colors.Reset) $($Colors.Dim)→ $Target$($Colors.Reset)"
+    } catch {
+        Print-Error "Failed to create symlink for $Name. You may need to enable Developer Mode in Windows Settings."
+        throw
+    }
+}
+
+function Test-Secrets {
+    param([string]$FilePath)
+    
+    if (-not (Test-Path $FilePath)) {
+        return $false
+    }
+    
+    $content = Get-Content $FilePath -Raw
+    return $content -match "bearer|api[_-]key|token|password|secret"
+}
+
+function Get-CustomAgents {
+    param(
+        [string]$UserAgentsDir,
+        [string]$RepoAgentsDir
+    )
+    
+    if (-not (Test-Path $UserAgentsDir)) {
+        return @()
+    }
+    
+    $customAgents = @()
+    $userAgents = Get-ChildItem -Path $UserAgentsDir -Filter "*.md" -File -ErrorAction SilentlyContinue
+    
+    foreach ($agent in $userAgents) {
+        $repoAgent = Join-Path $RepoAgentsDir $agent.Name
+        if (-not (Test-Path $repoAgent)) {
+            $customAgents += $agent.Name
+        }
+    }
+    
+    return $customAgents
+}
+
+# ======================================================================
+# PACKAGE MANAGER FUNCTIONS
+# ======================================================================
+
+function Install-Scoop {
+    Print-Section "$($Symbols.Package) Installing Scoop Package Manager"
+    
+    if (Test-Command "scoop") {
+        Print-Info "Scoop is already installed, skipping..."
+        return
+    }
+    
+    Print-Step "Installing Scoop" "Modern package manager for Windows"
+    
+    try {
+        # Set execution policy for current user
+        Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+        
+        # Install Scoop
+        Invoke-RestMethod get.scoop.sh | Invoke-Expression
+        
+        Print-Success "Scoop installed successfully!"
+        
+        # Add essential buckets
+        Print-Step "Adding Scoop buckets" "extras, nerd-fonts"
+        scoop bucket add extras 2>$null
+        scoop bucket add nerd-fonts 2>$null
+        
+        Print-Success "Scoop buckets added"
+    } catch {
+        Print-Error "Failed to install Scoop: $_"
+        Write-Host ""
+        Write-ColorOutput "Please install Scoop manually:" -Color "Yellow"
+        Write-Host "  irm get.scoop.sh | iex"
+        exit 1
+    }
+}
+
+function Install-WithScoop {
+    param(
+        [string]$Package,
+        [string]$DisplayName = $Package
+    )
+    
+    if (Test-Command $Package) {
+        Print-Info "$DisplayName is already installed, skipping..."
+        return
+    }
+    
+    Print-Step "Installing $DisplayName" "via Scoop"
+    
+    try {
+        scoop install $Package *>$null
+        Print-Success "Installed $DisplayName"
+    } catch {
+        Print-Error "Failed to install $DisplayName"
+        return
+    }
+}
+
+# ======================================================================
+# MAIN INSTALLATION FUNCTIONS
+# ======================================================================
+
+function Install-Dotfiles {
+    Print-Section "$($Symbols.Link) Linking Dotfiles"
+    
+    $scriptPath = $PSScriptRoot
+    
+    # Link .ripgreprc
+    if (Test-Path "$scriptPath\.ripgreprc") {
+        $ripgrepTarget = Join-Path $env:USERPROFILE ".ripgreprc"
+        New-Symlink -Source "$scriptPath\.ripgreprc" -Target $ripgrepTarget -Name ".ripgreprc"
+        
+        # Set environment variable
+        [Environment]::SetEnvironmentVariable("RIPGREP_CONFIG_PATH", $ripgrepTarget, "User")
+        Print-Info "RIPGREP_CONFIG_PATH environment variable set"
+    } else {
+        Print-Warning ".ripgreprc not found in $scriptPath"
+    }
+    
+    # Link scooter config
+    $scooterConfigSource = Join-Path $scriptPath "scooter.config.toml"
+    if (Test-Path $scooterConfigSource) {
+        $scooterConfigTarget = Join-Path $env:APPDATA "scooter\config.toml"
+        New-Symlink -Source $scooterConfigSource -Target $scooterConfigTarget -Name "Scooter config"
+    } else {
+        Print-Warning "scooter.config.toml not found in $scriptPath"
+    }
+    
+    # Create/Update PowerShell profile
+    Print-Step "Setting up PowerShell profile" "$PROFILE"
+    
+    if (-not (Test-Path $PROFILE)) {
+        New-Item -ItemType File -Path $PROFILE -Force | Out-Null
+        Print-Success "Created PowerShell profile"
+    }
+    
+    $profileContent = Get-Content $PROFILE -Raw -ErrorAction SilentlyContinue
+    
+    # Add RIPGREP_CONFIG_PATH if not present
+    if ($profileContent -notmatch "RIPGREP_CONFIG_PATH") {
+        Add-Content $PROFILE "`n# NairoVIM Configuration`n`$env:RIPGREP_CONFIG_PATH = '$ripgrepTarget'"
+        Print-Info "Added RIPGREP_CONFIG_PATH to PowerShell profile"
+    }
+    
+    Write-Host ""
+    Print-Success "All dotfiles linked successfully!"
+}
+
+function Install-Neovim {
+    Print-Section "$($Symbols.Rocket) Installing Neovim"
+    
+    Install-WithScoop -Package "neovim" -DisplayName "Neovim"
+    
+    Print-Step "Setting up Neovim configuration" "$env:LOCALAPPDATA\nvim"
+    
+    $nvimConfigSource = Join-Path $PSScriptRoot "nvim"
+    $nvimConfigTarget = Join-Path $env:LOCALAPPDATA "nvim"
+    
+    if (-not (Test-Path $nvimConfigSource)) {
+        Print-Error "Neovim configuration source not found at $nvimConfigSource"
+        return
+    }
+    
+    # Create symlink for nvim config
+    if (Test-Path $nvimConfigTarget) {
+        $item = Get-Item $nvimConfigTarget -Force
+        if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+            Print-Info "Neovim config symlink already exists, updating..."
+            Remove-Item $nvimConfigTarget -Force
+        } else {
+            $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+            $backupPath = "${nvimConfigTarget}.backup.${timestamp}"
+            Print-Warning "Neovim config exists, backing up to $backupPath"
+            Move-Item $nvimConfigTarget $backupPath -Force
+        }
+    }
+    
+    New-Item -ItemType SymbolicLink -Path $nvimConfigTarget -Value $nvimConfigSource -Force | Out-Null
+    Print-Success "Linked Neovim configuration"
+    
+    Write-Host ""
+    Print-Success "Neovim installation and configuration complete!"
+}
+
+function Install-WindowsTerminal {
+    Print-Section "$($Symbols.Gear) Installing Windows Terminal"
+    
+    # Check if Windows Terminal is already installed
+    $wtInstalled = $false
+    
+    # Check via winget
+    if (Test-Command "winget") {
+        $result = winget list --id Microsoft.WindowsTerminal 2>$null
+        if ($result -match "Microsoft.WindowsTerminal") {
+            $wtInstalled = $true
+        }
+    }
+    
+    # Check via Scoop
+    if (-not $wtInstalled) {
+        $scoopApps = scoop list 2>$null
+        if ($scoopApps -match "windows-terminal") {
+            $wtInstalled = $true
+        }
+    }
+    
+    if ($wtInstalled) {
+        Print-Info "Windows Terminal is already installed, skipping..."
+    } else {
+        Print-Step "Installing Windows Terminal" "via Scoop"
+        
+        try {
+            scoop install windows-terminal *>$null
+            Print-Success "Windows Terminal installed successfully!"
+        } catch {
+            Print-Warning "Failed to install via Scoop, trying winget..."
+            
+            if (Test-Command "winget") {
+                winget install --id Microsoft.WindowsTerminal -e --silent
+                Print-Success "Windows Terminal installed via winget!"
+            } else {
+                Print-Error "Failed to install Windows Terminal. Please install manually from Microsoft Store."
+            }
+        }
+    }
+    
+    # Link Windows Terminal settings
+    Print-Step "Setting up Windows Terminal configuration" "settings.json"
+    
+    $wtSettingsSource = Join-Path $PSScriptRoot "windows-terminal-settings.json"
+    
+    # Find Windows Terminal settings path
+    $wtPackages = Get-ChildItem "$env:LOCALAPPDATA\Packages" -Directory -Filter "Microsoft.WindowsTerminal*" -ErrorAction SilentlyContinue
+    
+    if ($wtPackages) {
+        $wtSettingsDir = Join-Path $wtPackages[0].FullName "LocalState"
+        $wtSettingsTarget = Join-Path $wtSettingsDir "settings.json"
+        
+        if (Test-Path $wtSettingsSource) {
+            New-Symlink -Source $wtSettingsSource -Target $wtSettingsTarget -Name "Windows Terminal settings"
+            Print-Success "Windows Terminal configuration linked!"
+        } else {
+            Print-Warning "windows-terminal-settings.json not found at $wtSettingsSource"
+            Print-Info "You can configure Windows Terminal manually via Settings (Ctrl+,)"
+        }
+    } else {
+        Print-Warning "Windows Terminal settings directory not found. Launch Windows Terminal once to create it."
+    }
+    
+    Write-Host ""
+    Print-Success "Windows Terminal setup complete!"
+}
+
+function Install-OhMyPosh {
+    Print-Section "$($Symbols.Sparkles) Installing Oh My Posh"
+    
+    Install-WithScoop -Package "oh-my-posh" -DisplayName "Oh My Posh"
+    
+    # Install a Nerd Font
+    Print-Step "Installing JetBrainsMono Nerd Font" "for proper icon display"
+    
+    try {
+        scoop install JetBrainsMono-NF-Mono *>$null
+        Print-Success "JetBrainsMono Nerd Font installed"
+    } catch {
+        Print-Warning "Failed to install Nerd Font. Install manually from https://www.nerdfonts.com/"
+    }
+    
+    # Configure PowerShell profile with Oh My Posh
+    Print-Step "Configuring PowerShell profile" "with Oh My Posh theme"
+    
+    if (-not (Test-Path $PROFILE)) {
+        New-Item -ItemType File -Path $PROFILE -Force | Out-Null
+    }
+    
+    $profileContent = Get-Content $PROFILE -Raw -ErrorAction SilentlyContinue
+    
+    if ($profileContent -notmatch "oh-my-posh init") {
+        $ohMyPoshInit = @"
+
+# Oh My Posh Configuration
+oh-my-posh init pwsh --config "$env:POSH_THEMES_PATH\tokyonight_storm.omp.json" | Invoke-Expression
+"@
+        Add-Content $PROFILE $ohMyPoshInit
+        Print-Success "Oh My Posh configured in PowerShell profile"
+    } else {
+        Print-Info "Oh My Posh already configured in profile"
+    }
+    
+    Write-Host ""
+    Print-Success "Oh My Posh installation complete!"
+}
+
+function Install-CLITools {
+    Print-Section "$($Symbols.Package) Installing CLI Tools"
+    
+    $tools = @(
+        @{Package = "fzf"; Name = "FZF (Terminal fuzzy finder)"},
+        @{Package = "ripgrep"; Name = "ripgrep (Fast search tool)"},
+        @{Package = "bat"; Name = "bat (Enhanced cat with syntax highlighting)"},
+        @{Package = "git"; Name = "Git (Version control)"},
+        @{Package = "lazygit"; Name = "Lazygit (Git TUI)"},
+        @{Package = "fd"; Name = "fd (Fast file finder)"}
+    )
+    
+    foreach ($tool in $tools) {
+        Install-WithScoop -Package $tool.Package -DisplayName $tool.Name
+    }
+    
+    # Check for scooter (might not be available on Windows)
+    Print-Step "Checking for scooter" "interactive search and replace"
+    if (Test-Command "scooter") {
+        Print-Info "Scooter is already installed"
+    } else {
+        try {
+            scoop install scooter *>$null
+            Print-Success "Installed scooter"
+        } catch {
+            Print-Warning "Scooter not available via Scoop. Skipping..."
+        }
+    }
+    
+    Write-Host ""
+    Print-Success "All CLI tools installed successfully!"
+}
+
+function Install-UV {
+    Print-Section "$($Symbols.Star) Installing UV/UVX"
+    
+    if (Test-Command "uv") {
+        Print-Info "UV is already installed, skipping..."
+        return
+    }
+    
+    Print-Step "Installing UV/UVX" "for Python/MCP plugins"
+    
+    try {
+        Invoke-RestMethod https://astral.sh/uv/install.ps1 | Invoke-Expression
+        Print-Success "UV/UVX installed successfully!"
+        Print-Info "UV/UVX is now available for MCP plugin management"
+    } catch {
+        Print-Error "Failed to install UV/UVX: $_"
+        Print-Warning "You can install manually from: https://astral.sh/uv"
+    }
+}
+
+function Install-Lazygit {
+    Print-Section "$($Symbols.Gear) Installing and Configuring Lazygit"
+    
+    # Lazygit is already installed in Install-CLITools, just configure it
+    Print-Step "Setting up Lazygit configuration" "$env:APPDATA\lazygit\config.yml"
+    
+    $lazygitConfigSource = Join-Path $PSScriptRoot "lazygit_config.yml"
+    $lazygitConfigTarget = Join-Path $env:APPDATA "lazygit\config.yml"
+    
+    if (Test-Path $lazygitConfigSource) {
+        New-Symlink -Source $lazygitConfigSource -Target $lazygitConfigTarget -Name "Lazygit config"
+        
+        # Set environment variable
+        [Environment]::SetEnvironmentVariable("CONFIG_DIR", (Join-Path $env:APPDATA "lazygit"), "User")
+        
+        Print-Success "Lazygit configuration linked successfully!"
+    } else {
+        Print-Warning "Lazygit configuration file not found at $lazygitConfigSource"
+    }
+}
+
+function Install-OpenCode {
+    Print-Section "$($Symbols.Star) Installing and Configuring OpenCode"
+    
+    # Install OpenCode
+    if (-not (Test-Command "opencode")) {
+        Print-Step "Installing OpenCode" "AI-powered coding assistant"
+        
+        try {
+            # Add anomalyco bucket
+            scoop bucket add anomalyco https://github.com/anomalyco/scoop-bucket 2>$null
+            scoop install opencode *>$null
+            Print-Success "OpenCode installed successfully!"
+        } catch {
+            Print-Error "Failed to install OpenCode via Scoop"
+            Print-Info "Visit https://opencode.ai for manual installation"
+            return
+        }
+    } else {
+        Print-Info "OpenCode is already installed, skipping..."
+    }
+    
+    # Setup OpenCode configuration
+    Print-Step "Setting up OpenCode configuration" "$env:APPDATA\opencode"
+    
+    $opencodeConfigSource = Join-Path $PSScriptRoot "opencode_global_config"
+    $opencodeConfigTarget = Join-Path $env:APPDATA "opencode"
+    
+    if (-not (Test-Path $opencodeConfigSource)) {
+        Print-Error "OpenCode configuration source not found at $opencodeConfigSource"
+        return
+    }
+    
+    # Create target directory
+    if (-not (Test-Path $opencodeConfigTarget)) {
+        New-Item -ItemType Directory -Path $opencodeConfigTarget -Force | Out-Null
+    }
+    
+    # Initialize backup session
+    $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+    $backupSession = Join-Path $opencodeConfigTarget ".backups\$timestamp"
+    New-Item -ItemType Directory -Path $backupSession -Force | Out-Null
+    "OpenCode configuration backup - $(Get-Date)" | Out-File "$backupSession\info.txt"
+    
+    # Handle opencode.json with secret detection
+    $opencodeJsonSource = Join-Path $opencodeConfigSource "opencode.json"
+    $opencodeJsonTarget = Join-Path $opencodeConfigTarget "opencode.json"
+    
+    if (Test-Path $opencodeJsonSource) {
+        if ((Test-Path $opencodeJsonTarget) -and -not ((Get-Item $opencodeJsonTarget -Force).Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
+            if (Test-Secrets $opencodeJsonTarget) {
+                Print-Warning "Detected potential secrets/API keys in your opencode.json!"
+                Write-Host ""
+                Write-ColorOutput "Your configuration may contain sensitive data" -Color "Yellow"
+                Write-Host ""
+                Write-ColorOutput "Options:" -Color "Cyan"
+                Write-Host "  1) Backup current config, symlink to repo (you'll need to re-add secrets)"
+                Write-Host "  2) Keep your current file (recommended if you have custom secrets)"
+                Write-Host "  3) Abort installation"
+                Write-Host ""
+                $choice = Read-Host "Choose [1-3] (default: 2)"
+                if ([string]::IsNullOrWhiteSpace($choice)) { $choice = "2" }
+                
+                switch ($choice) {
+                    "1" {
+                        $backupPath = Join-Path $backupSession "opencode.json"
+                        Copy-Item $opencodeJsonTarget $backupPath -Force
+                        Print-Success "Backed up to: $backupPath"
+                        Remove-Item $opencodeJsonTarget -Force
+                        New-Item -ItemType SymbolicLink -Path $opencodeJsonTarget -Value $opencodeJsonSource -Force | Out-Null
+                        Print-Success "Symlinked opencode.json (restore secrets from backup)"
+                        Write-Host "    $($Colors.Dim)To restore secrets: review $backupPath$($Colors.Reset)"
+                    }
+                    "2" {
+                        Print-Info "Keeping your existing opencode.json (skipping symlink)"
+                    }
+                    "3" {
+                        Print-Error "Installation aborted by user"
+                        return
+                    }
+                    default {
+                        Print-Error "Invalid choice, keeping existing file"
+                    }
+                }
+            } else {
+                New-Symlink -Source $opencodeJsonSource -Target $opencodeJsonTarget -Name "OpenCode config"
+            }
+        } else {
+            New-Symlink -Source $opencodeJsonSource -Target $opencodeJsonTarget -Name "OpenCode config"
+        }
+    } else {
+        Print-Warning "opencode.json not found at $opencodeJsonSource"
+    }
+    
+    # Handle agents directory with custom agent detection
+    $agentsSource = Join-Path $opencodeConfigSource "agents"
+    $agentsTarget = Join-Path $opencodeConfigTarget "agents"
+    
+    if (Test-Path $agentsSource) {
+        if ((Test-Path $agentsTarget) -and -not ((Get-Item $agentsTarget -Force).Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
+            Print-Step "Analyzing existing agents directory" "checking for custom agents"
+            
+            $customAgents = Get-CustomAgents -UserAgentsDir $agentsTarget -RepoAgentsDir $agentsSource
+            
+            if ($customAgents.Count -gt 0) {
+                Print-Warning "Found $($customAgents.Count) custom agent(s) not in repository:"
+                foreach ($agent in $customAgents) {
+                    Write-Host "    $($Colors.Yellow)• $agent$($Colors.Reset)"
+                }
+                Write-Host ""
+                Write-ColorOutput "Options:" -Color "Cyan"
+                Write-Host "  1) Backup and symlink (custom agents preserved in backup)"
+                Write-Host "  2) Keep existing agents directory (recommended)"
+                Write-Host ""
+                $choice = Read-Host "Choose [1-2] (default: 2)"
+                if ([string]::IsNullOrWhiteSpace($choice)) { $choice = "2" }
+                
+                switch ($choice) {
+                    "1" {
+                        $backupPath = Join-Path $backupSession "agents"
+                        Copy-Item $agentsTarget $backupPath -Recurse -Force
+                        Print-Success "Backed up agents to: $backupPath"
+                        Remove-Item $agentsTarget -Recurse -Force
+                        New-Item -ItemType SymbolicLink -Path $agentsTarget -Value $agentsSource -Force | Out-Null
+                        Write-Host "    $($Colors.Green)$($Symbols.Link) OpenCode agents$($Colors.Reset) $($Colors.Dim)→ $agentsTarget$($Colors.Reset)"
+                        Print-Info "Your custom agents are in: $backupPath"
+                    }
+                    "2" {
+                        Print-Info "Keeping your existing agents directory (skipping symlink)"
+                    }
+                    default {
+                        Print-Error "Invalid choice, keeping existing directory"
+                    }
+                }
+            } else {
+                New-Symlink -Source $agentsSource -Target $agentsTarget -Name "OpenCode agents"
+            }
+        } else {
+            New-Symlink -Source $agentsSource -Target $agentsTarget -Name "OpenCode agents"
+        }
+    } else {
+        Print-Warning "agents directory not found at $agentsSource"
+    }
+    
+    # Handle other configuration items (commands, etc.)
+    Print-Step "Symlinking additional OpenCode configuration" "commands and other files"
+    
+    $items = Get-ChildItem $opencodeConfigSource -ErrorAction SilentlyContinue
+    foreach ($item in $items) {
+        $itemName = $item.Name
+        $itemTarget = Join-Path $opencodeConfigTarget $itemName
+        
+        # Skip already processed items
+        if ($itemName -eq "opencode.json" -or $itemName -eq "agents") {
+            continue
+        }
+        
+        if ($item.PSIsContainer) {
+            New-Symlink -Source $item.FullName -Target $itemTarget -Name "OpenCode $itemName"
+        } else {
+            New-Symlink -Source $item.FullName -Target $itemTarget -Name "OpenCode $itemName"
+        }
+    }
+    
+    # Show backup session summary
+    Write-Host ""
+    $backupContents = Get-ChildItem $backupSession -ErrorAction SilentlyContinue | Where-Object { $_.Name -ne "info.txt" }
+    if ($backupContents) {
+        Print-Info "Backups created in: $backupSession"
+        Write-Host "    $($Colors.Dim)To restore: copy backups from this directory to $opencodeConfigTarget$($Colors.Reset)"
+    } else {
+        Remove-Item $backupSession -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item (Join-Path $opencodeConfigTarget ".backups") -Force -ErrorAction SilentlyContinue
+    }
+    
+    Write-Host ""
+    Print-Success "OpenCode installation and configuration complete!"
+}
+
+function Print-InstallationSummary {
+    Write-Host ""
+    Write-ColorOutput "╔══════════════════════════════════════════════════════════════════════════════════════╗" -Color "Magenta"
+    Write-ColorOutput "║  🎉 INSTALLATION COMPLETE! 🎉" -Color "Green"
+    Write-ColorOutput "╚══════════════════════════════════════════════════════════════════════════════════════╝" -Color "Magenta"
+    Write-Host ""
+    Write-ColorOutput "📋 Installation Summary:" -Color "Cyan"
+    Write-Host "$($Symbols.CheckMark) Dotfiles linked (.ripgreprc, scooter config)"
+    Write-Host "$($Symbols.CheckMark) Neovim installed and configured"
+    Write-Host "$($Symbols.CheckMark) Windows Terminal installed and configured"
+    Write-Host "$($Symbols.CheckMark) Oh My Posh installed with TokyoNight theme"
+    Write-Host "$($Symbols.CheckMark) CLI tools installed (fzf, ripgrep, bat, git, lazygit)"
+    Write-Host "$($Symbols.CheckMark) UV/UVX installed for MCP plugins"
+    Write-Host "$($Symbols.CheckMark) Lazygit installed and configured"
+    Write-Host "$($Symbols.CheckMark) OpenCode installed and configured"
+    Write-Host ""
+    Write-ColorOutput "🚀 Next Steps:" -Color "Yellow"
+    Write-Host "1. Restart your PowerShell session or run: . `$PROFILE"
+    Write-Host "2. Launch Windows Terminal (search 'Windows Terminal' in Start Menu)"
+    Write-Host "3. Run 'nvim' to start Neovim and let plugins install"
+    Write-Host "4. In Neovim, run ':Tutorial' to start the interactive tutorial"
+    Write-Host "5. Configure your language servers as needed"
+    Write-Host ""
+    Write-ColorOutput "💡 Useful Tips:" -Color "Blue"
+    Write-Host "• Enable Developer Mode in Windows Settings for better symlink support"
+    Write-Host "• Set Windows Terminal as your default terminal in Windows Settings"
+    Write-Host "• Install PowerShell 7+ for better experience: scoop install pwsh"
+    Write-Host ""
+    Write-ColorOutput "🎊 Happy coding with NairoVIM on Windows! 🎊" -Color "Green"
+    Write-Host ""
+}
+
+# ======================================================================
+# MAIN EXECUTION
+# ======================================================================
+
+function Main {
+    # Print welcome header
+    Print-Header "🚀 NairoVIM Installation Script for Windows 🚀"
+    
+    Write-ColorOutput "Welcome to the NairoVIM installation script for Windows!" -Color "Cyan"
+    Write-Host "$($Colors.Dim)This script will install and configure your complete development environment.$($Colors.Reset)"
+    Write-Host ""
+    
+    # Check PowerShell version
+    if ($PSVersionTable.PSVersion.Major -lt 5) {
+        Print-Error "PowerShell 5.1 or later is required. Current version: $($PSVersionTable.PSVersion)"
+        exit 1
+    }
+    
+    # Check for admin privileges (warn but don't require)
+    if (-not (Test-AdminPrivileges)) {
+        Print-Warning "Not running as administrator. Some features may require elevation."
+        Print-Info "Consider enabling Developer Mode in Windows Settings for better symlink support."
+        Write-Host ""
+    }
+    
+    # Check prerequisites
+    Print-Step "Checking prerequisites" "Scoop package manager"
+    
+    # Start installation process
+    Write-Host ""
+    Write-ColorOutput "🔧 Starting installation process..." -Color "Cyan"
+    
+    # Execute installation steps
+    Install-Scoop
+    Install-Dotfiles
+    Install-Neovim
+    Install-WindowsTerminal
+    Install-OhMyPosh
+    Install-CLITools
+    Install-UV
+    Install-Lazygit
+    Install-OpenCode
+    
+    # Print final summary
+    Print-InstallationSummary
+}
+
+# ======================================================================
+# ERROR HANDLING & CLEANUP
+# ======================================================================
+
+trap {
+    Write-Host ""
+    Print-Error "Installation interrupted or failed: $_"
+    Write-ColorOutput "Please check the error messages above and try again." -Color "Yellow"
+    Write-Host ""
+    Write-ColorOutput "Need help? Check the documentation or open an issue on GitHub." -Color "Blue"
+    exit 1
+}
+
+# ======================================================================
+# SCRIPT ENTRY POINT
+# ======================================================================
+
+# Run main function
+Main

--- a/install.ps1
+++ b/install.ps1
@@ -40,18 +40,18 @@ $Script:Colors = @{
 
 # Enhanced symbols with Unicode support
 $Script:Symbols = @{
-    CheckMark  = "✓"
-    CrossMark  = "✗"
-    ArrowRight = "→"
-    Star       = "★"
-    Gear       = "⚙"
-    Rocket     = "🚀"
-    Package    = "📦"
-    Link       = "🔗"
-    Sparkles   = "✨"
-    Hourglass  = "⏳"
-    Warning    = "⚠"
-    Info       = "ℹ"
+    CheckMark  = [char]0x2713  # ✓
+    CrossMark  = [char]0x2717  # ✗
+    ArrowRight = [char]0x2192  # →
+    Star       = [char]0x2605  # ★
+    Gear       = [char]0x2699  # ⚙
+    Rocket     = [char]0x1F680 # 🚀
+    Package    = [char]0x1F4E6 # 📦
+    Link       = [char]0x1F517 # 🔗
+    Sparkles   = [char]0x2728  # ✨
+    Hourglass  = [char]0x23F3  # ⏳
+    Warning    = [char]0x26A0  # ⚠
+    Info       = [char]0x2139  # ℹ
 }
 
 # ======================================================================
@@ -70,9 +70,13 @@ function Print-Header {
     param([string]$Title)
     
     Write-Host ""
-    Write-ColorOutput "╔══════════════════════════════════════════════════════════════════════════════════════╗" -Color "Cyan"
-    Write-ColorOutput "║  $Title" -Color "Magenta"
-    Write-ColorOutput "╚══════════════════════════════════════════════════════════════════════════════════════╝" -Color "Cyan"
+    $topBorder = [char]0x2554 + ([char]0x2550 * 86) + [char]0x2557
+    $titleLine = [char]0x2551 + "  $Title"
+    $bottomBorder = [char]0x255A + ([char]0x2550 * 86) + [char]0x255D
+    
+    Write-ColorOutput $topBorder -Color "Cyan"
+    Write-ColorOutput $titleLine -Color "Magenta"
+    Write-ColorOutput $bottomBorder -Color "Cyan"
     Write-Host ""
 }
 
@@ -80,7 +84,8 @@ function Print-Section {
     param([string]$Title)
     
     Write-Host ""
-    Write-ColorOutput "▓▓▓ $Title ▓▓▓" -Color "Blue"
+    $prefix = [char]0x2593 + [char]0x2593 + [char]0x2593  # ▓▓▓
+    Write-ColorOutput "$prefix $Title $prefix" -Color "Blue"
     Write-Host ""
 }
 
@@ -784,11 +789,15 @@ function Install-OpenCode {
 
 function Print-InstallationSummary {
     Write-Host ""
-    Write-ColorOutput "╔══════════════════════════════════════════════════════════════════════════════════════╗" -Color "Magenta"
-    Write-ColorOutput "║  🎉 INSTALLATION COMPLETE! 🎉" -Color "Green"
-    Write-ColorOutput "╚══════════════════════════════════════════════════════════════════════════════════════╝" -Color "Magenta"
+    $topBorder = [char]0x2554 + ([char]0x2550 * 86) + [char]0x2557
+    $titleLine = [char]0x2551 + "  " + [char]0x1F389 + " INSTALLATION COMPLETE! " + [char]0x1F389
+    $bottomBorder = [char]0x255A + ([char]0x2550 * 86) + [char]0x255D
+    
+    Write-ColorOutput $topBorder -Color "Magenta"
+    Write-ColorOutput $titleLine -Color "Green"
+    Write-ColorOutput $bottomBorder -Color "Magenta"
     Write-Host ""
-    Write-ColorOutput "📋 Installation Summary:" -Color "Cyan"
+    Write-ColorOutput "$([char]0x1F4CB) Installation Summary:" -Color "Cyan"
     Write-Host "$($Symbols.CheckMark) Build tools installed (MinGW, CMake)"
     Write-Host "$($Symbols.CheckMark) Dotfiles linked (.ripgreprc, scooter config)"
     Write-Host "$($Symbols.CheckMark) Neovim installed and configured"
@@ -799,19 +808,19 @@ function Print-InstallationSummary {
     Write-Host "$($Symbols.CheckMark) Lazygit installed and configured"
     Write-Host "$($Symbols.CheckMark) OpenCode installed and configured"
     Write-Host ""
-    Write-ColorOutput "🚀 Next Steps:" -Color "Yellow"
+    Write-ColorOutput "$([char]0x1F680) Next Steps:" -Color "Yellow"
     Write-Host "1. Restart your PowerShell session or run: . `$PROFILE"
     Write-Host "2. Launch Windows Terminal (search 'Windows Terminal' in Start Menu)"
     Write-Host "3. Run 'nvim' to start Neovim and let plugins install"
     Write-Host "4. In Neovim, run ':Tutorial' to start the interactive tutorial"
     Write-Host "5. Configure your language servers as needed"
     Write-Host ""
-    Write-ColorOutput "💡 Useful Tips:" -Color "Blue"
-    Write-Host "• Enable Developer Mode in Windows Settings for better symlink support"
-    Write-Host "• Set Windows Terminal as your default terminal in Windows Settings"
-    Write-Host "• Install PowerShell 7+ for better experience: scoop install pwsh"
+    Write-ColorOutput "$([char]0x1F4A1) Useful Tips:" -Color "Blue"
+    Write-Host "$([char]0x2022) Enable Developer Mode in Windows Settings for better symlink support"
+    Write-Host "$([char]0x2022) Set Windows Terminal as your default terminal in Windows Settings"
+    Write-Host "$([char]0x2022) Install PowerShell 7+ for better experience: scoop install pwsh"
     Write-Host ""
-    Write-ColorOutput "🎊 Happy coding with NairoVIM on Windows! 🎊" -Color "Green"
+    Write-ColorOutput "$([char]0x1F38A) Happy coding with NairoVIM on Windows! $([char]0x1F38A)" -Color "Green"
     Write-Host ""
 }
 
@@ -821,7 +830,7 @@ function Print-InstallationSummary {
 
 function Main {
     # Print welcome header
-    Print-Header "🚀 NairoVIM Installation Script for Windows 🚀"
+    Print-Header "$([char]0x1F680) NairoVIM Installation Script for Windows $([char]0x1F680)"
     
     Write-ColorOutput "Welcome to the NairoVIM installation script for Windows!" -Color "Cyan"
     Write-Host "$($Colors.Dim)This script will install and configure your complete development environment.$($Colors.Reset)"
@@ -845,7 +854,7 @@ function Main {
     
     # Start installation process
     Write-Host ""
-    Write-ColorOutput "🔧 Starting installation process..." -Color "Cyan"
+    Write-ColorOutput "$([char]0x1F527) Starting installation process..." -Color "Cyan"
     
     # Execute installation steps
     Install-Scoop

--- a/install.sh
+++ b/install.sh
@@ -336,6 +336,99 @@ install_build_tools() {
     print_success "Build tools installation complete!"
 }
 
+install_development_tools() {
+    print_section "${PACKAGE} Installing Development Tools (Optional)"
+    
+    print_info "Development tools enable LSP servers for various languages in Neovim"
+    print_info "Includes: Node.js (npm), Go, Python"
+    echo ""
+    
+    # Prompt user with default Y
+    read -p "Install development tools? [Y/n] " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Nn]$ ]]; then
+        print_info "Skipping development tools installation"
+        print_info "You can install later with: ${bold}brew install node go python${textreset}"
+        return
+    fi
+    
+    echo ""
+    print_step "Installing development tools" "Node.js, Go, Python"
+    
+    # Detect OS and install accordingly
+    case "$(uname -s)" in
+        Darwin*)
+            # macOS - Use Homebrew
+            install_with_brew "node" "Node.js (npm)"
+            install_with_brew "go" "Go (golang)"
+            install_with_brew "python@3" "Python"
+            ;;
+        Linux*)
+            # Linux - Detect and use appropriate package manager
+            if command_exists apt-get; then
+                print_step "Installing via apt" "nodejs, npm, golang, python3"
+                sudo apt-get update -qq
+                sudo apt-get install -y nodejs npm golang python3 python3-pip
+            elif command_exists dnf; then
+                print_step "Installing via dnf" "nodejs, golang, python3"
+                sudo dnf install -y nodejs golang python3 python3-pip
+            elif command_exists pacman; then
+                print_step "Installing via pacman" "nodejs, go, python"
+                sudo pacman -S --noconfirm nodejs npm go python python-pip
+            elif command_exists zypper; then
+                print_step "Installing via zypper" "nodejs, go, python3"
+                sudo zypper install -y nodejs npm go python3 python3-pip
+            else
+                print_warning "Could not detect package manager. Please install manually:"
+                print_info "  Node.js: https://nodejs.org/"
+                print_info "  Go: https://golang.org/dl/"
+                print_info "  Python: https://www.python.org/downloads/"
+                return
+            fi
+            ;;
+        *)
+            print_warning "Unsupported OS: $(uname -s)"
+            print_info "Please install Node.js, Go, and Python manually"
+            return
+            ;;
+    esac
+    
+    echo ""
+    print_step "Verifying installations" "checking versions"
+    
+    # Verify Node.js/npm
+    if command_exists node && command_exists npm; then
+        local node_version=$(node --version 2>/dev/null || echo "unknown")
+        local npm_version=$(npm --version 2>/dev/null || echo "unknown")
+        print_success "Node.js $node_version and npm $npm_version installed"
+        print_info "${dim}  Enables: TypeScript, JavaScript, HTML, CSS, JSON LSP servers${textreset}"
+    else
+        print_warning "Node.js/npm verification failed - may need shell restart"
+    fi
+    
+    # Verify Go
+    if command_exists go; then
+        local go_version=$(go version 2>/dev/null | awk '{print $3}' || echo "unknown")
+        print_success "Go $go_version installed"
+        print_info "${dim}  Enables: Go language server (gopls), gofumpt${textreset}"
+    else
+        print_warning "Go verification failed - may need shell restart"
+    fi
+    
+    # Verify Python
+    if command_exists python3 && command_exists pip3; then
+        local python_version=$(python3 --version 2>/dev/null | awk '{print $2}' || echo "unknown")
+        print_success "Python $python_version installed"
+        print_info "${dim}  Enables: Python LSP servers and formatters${textreset}"
+    else
+        print_warning "Python verification failed - may need shell restart"
+    fi
+    
+    echo ""
+    print_success "Development tools installation complete!"
+    print_info "After installation, run ${bold}:Mason${textreset} in Neovim to install LSP servers"
+}
+
 install_dotfiles() {
     print_section "${LINK} Linking Dotfiles"
 
@@ -804,6 +897,7 @@ print_installation_summary() {
     echo ""
     echo "${bold}${cyan}📋 Installation Summary:${textreset}"
     echo "${green}${CHECK_MARK}${textreset} Build tools installed (gcc/clang, make, cmake)"
+    echo "${green}${CHECK_MARK}${textreset} Development tools installed (Node.js, Go, Python) [optional]"
     echo "${green}${CHECK_MARK}${textreset} Dotfiles linked (.zshrc, .vimrc, .tmux.conf, .ripgreprc)"
     echo "${green}${CHECK_MARK}${textreset} Neovim installed and configured"
     echo "${green}${CHECK_MARK}${textreset} Tmux installed with Plugin Manager (TPM)"
@@ -860,6 +954,7 @@ main() {
 
     # Execute installation steps
     install_build_tools
+    install_development_tools
     install_dotfiles
     install_neovim
     install_tmux

--- a/install.sh
+++ b/install.sh
@@ -207,6 +207,135 @@ clone_repository() {
 # MAIN INSTALLATION FUNCTIONS
 # ======================================================================
 
+install_build_tools() {
+    print_section "${GEAR} Installing Build Tools"
+    
+    print_info "Installing C compiler toolchain for Neovim plugin compilation..."
+    print_info "This enables: telescope-fzf-native, nvim-treesitter, CopilotChat"
+    
+    # Detect OS
+    local os_type="$(uname -s)"
+    
+    case "$os_type" in
+        Darwin*)
+            # macOS - Install Xcode Command Line Tools
+            if ! command_exists gcc || ! command_exists make; then
+                print_step "Installing Xcode Command Line Tools" "gcc, make, clang"
+                
+                # Check if Xcode CLI tools are already installed
+                if xcode-select -p &>/dev/null; then
+                    print_info "Xcode Command Line Tools already installed"
+                else
+                    # Install Xcode CLI tools
+                    xcode-select --install 2>/dev/null || true
+                    
+                    print_warning "Please complete the Xcode Command Line Tools installation dialog"
+                    print_info "After installation completes, re-run this script: ./install.sh"
+                    
+                    # Wait for user to complete installation
+                    echo ""
+                    read -p "Press Enter after completing the installation (or Ctrl+C to exit)..."
+                fi
+            fi
+            
+            # Install cmake via Homebrew
+            install_with_brew "cmake" "CMake"
+            ;;
+            
+        Linux*)
+            # Linux - Use package manager
+            print_step "Installing build tools" "gcc, make, cmake"
+            
+            if command_exists apt-get; then
+                # Debian/Ubuntu
+                if ! command_exists gcc || ! command_exists make; then
+                    sudo apt-get update -qq
+                    sudo apt-get install -y build-essential cmake
+                    print_success "Installed build-essential and CMake (apt)"
+                else
+                    print_info "Build tools already installed"
+                fi
+            elif command_exists dnf; then
+                # Fedora/RHEL
+                if ! command_exists gcc || ! command_exists make; then
+                    sudo dnf groupinstall -y "Development Tools"
+                    sudo dnf install -y cmake
+                    print_success "Installed Development Tools and CMake (dnf)"
+                else
+                    print_info "Build tools already installed"
+                fi
+            elif command_exists pacman; then
+                # Arch Linux
+                if ! command_exists gcc || ! command_exists make; then
+                    sudo pacman -S --noconfirm base-devel cmake
+                    print_success "Installed base-devel and CMake (pacman)"
+                else
+                    print_info "Build tools already installed"
+                fi
+            else
+                print_warning "Unsupported Linux distribution. Please install gcc, make, and cmake manually."
+            fi
+            ;;
+            
+        *)
+            print_warning "Unsupported OS: $os_type. Please install gcc, make, and cmake manually."
+            ;;
+    esac
+    
+    # Verify installations
+    print_step "Verifying build tools installation"
+    
+    local build_tools_ready=true
+    
+    if command_exists gcc; then
+        local gcc_version=$(gcc --version 2>&1 | head -n1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+        if [[ -n "$gcc_version" ]]; then
+            print_success "GCC compiler ready (v$gcc_version)"
+        else
+            print_success "GCC compiler ready"
+        fi
+    elif command_exists clang; then
+        local clang_version=$(clang --version 2>&1 | head -n1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+        if [[ -n "$clang_version" ]]; then
+            print_success "Clang compiler ready (v$clang_version)"
+        else
+            print_success "Clang compiler ready"
+        fi
+    else
+        print_warning "No C compiler found (gcc or clang)"
+        build_tools_ready=false
+    fi
+    
+    if command_exists make; then
+        print_success "GNU Make ready"
+    else
+        print_warning "Make not found in PATH"
+        build_tools_ready=false
+    fi
+    
+    if command_exists cmake; then
+        local cmake_version=$(cmake --version 2>&1 | head -n1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+        if [[ -n "$cmake_version" ]]; then
+            print_success "CMake ready (v$cmake_version)"
+        else
+            print_success "CMake ready"
+        fi
+    else
+        print_warning "CMake not found in PATH"
+        build_tools_ready=false
+    fi
+    
+    if [[ "$build_tools_ready" = true ]]; then
+        print_success "Build tools configured successfully"
+    else
+        print_warning "Some build tools may require shell restart to be available"
+        print_info "Restart your terminal, then run: ./install.sh"
+    fi
+    
+    echo ""
+    print_success "Build tools installation complete!"
+}
+
 install_dotfiles() {
     print_section "${LINK} Linking Dotfiles"
 
@@ -674,6 +803,7 @@ print_installation_summary() {
     echo "${bold}${magenta}╚══════════════════════════════════════════════════════════════════════════════════════╝${textreset}"
     echo ""
     echo "${bold}${cyan}📋 Installation Summary:${textreset}"
+    echo "${green}${CHECK_MARK}${textreset} Build tools installed (gcc/clang, make, cmake)"
     echo "${green}${CHECK_MARK}${textreset} Dotfiles linked (.zshrc, .vimrc, .tmux.conf, .ripgreprc)"
     echo "${green}${CHECK_MARK}${textreset} Neovim installed and configured"
     echo "${green}${CHECK_MARK}${textreset} Tmux installed with Plugin Manager (TPM)"
@@ -729,6 +859,7 @@ main() {
     echo "${bold}${cyan}🔧 Starting installation process...${textreset}"
 
     # Execute installation steps
+    install_build_tools
     install_dotfiles
     install_neovim
     install_tmux

--- a/install.sh
+++ b/install.sh
@@ -60,7 +60,12 @@ print_section() {
 
 # Print step with icon
 print_step() {
-    echo "${cyan}${HOURGLASS} ${bold}$1${textreset} ${dim}$2${textreset}"
+    local description="${2:-}"  # Make second parameter optional
+    if [[ -n "$description" ]]; then
+        echo "${cyan}${HOURGLASS} ${bold}$1${textreset} ${dim}$description${textreset}"
+    else
+        echo "${cyan}${HOURGLASS} ${bold}$1${textreset}"
+    fi
 }
 
 # Print success message

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -1,5 +1,5 @@
 {
-  "CopilotChat.nvim": { "branch": "main", "commit": "07dcc188bc488b2dafa9324bd42088640bee3d19" },
+  "CopilotChat.nvim": { "branch": "main", "commit": "69199d46b56f67a226789da256264c6291c4e63d" },
   "ReplaceWithRegister": { "branch": "master", "commit": "832efc23111d19591d495dc72286de2fb0b09345" },
   "avante.nvim": { "branch": "main", "commit": "fde9a524457d17661618678f085649d4e8d3fd6f" },
   "bufferline.nvim": { "branch": "main", "commit": "655133c3b4c3e5e05ec549b9f8cc2894ac6f51b3" },
@@ -45,10 +45,10 @@
   "nvim-treesitter": { "branch": "master", "commit": "42fc28ba918343ebfd5565147a42a26580579482" },
   "nvim-ts-autotag": { "branch": "main", "commit": "db15f2e0df2f5db916e511e3fffb682ef2f6354f" },
   "nvim-web-devicons": { "branch": "master", "commit": "803353450c374192393f5387b6a0176d0972b848" },
-  "opencode.nvim": { "branch": "main", "commit": "ed2a936b163df9e92ef210daad3a9ae89ca7e073" },
+  "opencode.nvim": { "branch": "main", "commit": "632ec5879295a3103fa39742b2e3f0639496c96f" },
   "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },
   "quick-scope": { "branch": "master", "commit": "6cee1d9e0b9ac0fbffeb538d4a5ba9f5628fabbc" },
-  "render-markdown.nvim": { "branch": "main", "commit": "48934b49a2363b49ae1d698ed4cb30fb79d7efe8" },
+  "render-markdown.nvim": { "branch": "main", "commit": "b3efd6408e4e4d66d6caaee0579e72b579bc0884" },
   "snacks.nvim": { "branch": "main", "commit": "fe7cfe9800a182274d0f868a74b7263b8c0c020b" },
   "telescope-fzf-native.nvim": { "branch": "main", "commit": "6fea601bd2b694c6f2ae08a6c6fab14930c60e2c" },
   "telescope.nvim": { "branch": "0.1.x", "commit": "a0bbec21143c7bc5f8bb02e0005fa0b982edc026" },
@@ -57,6 +57,6 @@
   "vim-highlightedyank": { "branch": "master", "commit": "285a61425e79742997bbde76a91be6189bc988fb" },
   "vim-peekaboo": { "branch": "master", "commit": "2a8a3187ba6b15201b2563a3f0331fcdf49da36c" },
   "vim-surround": { "branch": "master", "commit": "3d188ed2113431cf8dac77be61b842acb64433d9" },
-  "vscode-js-debug": { "branch": "main", "commit": "74702375c67744e2f123d89ef950d7b6859c6f16" },
+  "vscode-js-debug": { "branch": "main", "commit": "877d8d4bed9521c6c8478e51451dfcacf649c6ee" },
   "which-key.nvim": { "branch": "main", "commit": "3aab2147e74890957785941f0c1ad87d0a44c15a" }
 }

--- a/nvim/lua/nairovim/core/options.lua
+++ b/nvim/lua/nairovim/core/options.lua
@@ -8,9 +8,23 @@ g.mapleader = ","
 g.maplocalleader = " "
 
 ----------------------------------------------------------------------
--- 2. Shell
+-- 2. Shell (Cross-platform)
 ----------------------------------------------------------------------
-opt.shell = "/bin/bash"
+if vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1 then
+    -- Windows: Use PowerShell 7 with fallback to PowerShell 5.1
+    if vim.fn.executable("pwsh") == 1 then
+        opt.shell = "pwsh"
+    else
+        opt.shell = "powershell"
+    end
+    -- Windows shell flags for proper command execution
+    opt.shellcmdflag = "-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command"
+    opt.shellquote = ""
+    opt.shellxquote = ""
+else
+    -- Unix/macOS: Use bash
+    opt.shell = "/bin/bash"
+end
 
 ----------------------------------------------------------------------
 -- 3. Line Numbers

--- a/nvim/lua/nairovim/plugins/ai/copilot-chat.lua
+++ b/nvim/lua/nairovim/plugins/ai/copilot-chat.lua
@@ -5,7 +5,26 @@ return {
             { "zbirenbaum/copilot.lua" },
             { "nvim-lua/plenary.nvim", branch = "master" },
         },
-        build = "make tiktoken",
+        build = function()
+            -- Windows-specific: Use conditional build with fallback
+            if vim.fn.has("win32") == 1 then
+                -- Attempt to build tiktoken, gracefully degrade if fails
+                local handle = io.popen("make tiktoken 2>&1")
+                if handle then
+                    local result = handle:read("*a")
+                    handle:close()
+                    if result:match("[Ee]rror") or result:match("not found") then
+                        vim.notify(
+                            "CopilotChat: tiktoken build failed, plugin will use fallback mode",
+                            vim.log.levels.WARN
+                        )
+                    end
+                end
+            else
+                -- Unix/macOS: Standard make
+                vim.fn.system("make tiktoken")
+            end
+        end,
 
         config = function()
             -- Lazy requires for performance

--- a/nvim/lua/nairovim/plugins/lsp/mason.lua
+++ b/nvim/lua/nairovim/plugins/lsp/mason.lua
@@ -54,14 +54,24 @@ return {
         })
 
         ----------------------------------------------------------------------
-        -- 6. Mason UI Setup
+        -- 6. C# Language Server Setup
+        ----------------------------------------------------------------------
+        vim.lsp.config("csharp_ls", {
+            capabilities = capabilities,
+            cmd_env = {
+                DOTNET_ROOT = "C:\\Program Files\\dotnet",
+            },
+        })
+
+        ----------------------------------------------------------------------
+        -- 7. Mason UI Setup
         ----------------------------------------------------------------------
         mason.setup({
             ui = { border = "rounded" },
         })
 
         ----------------------------------------------------------------------
-        -- 7. Mason LSPConfig Setup
+        -- 8. Mason LSPConfig Setup
         ----------------------------------------------------------------------
         mason_lspconfig.setup({
             ensure_installed = ensure_lsp,
@@ -69,7 +79,7 @@ return {
         })
 
         ----------------------------------------------------------------------
-        -- 8. Mason Null-LS Setup
+        -- 9. Mason Null-LS Setup
         ----------------------------------------------------------------------
         mason_null_ls.setup({
             ensure_installed = ensure_null_ls,
@@ -78,7 +88,7 @@ return {
         })
 
         -- --------------------------------------------------------------------
-        -- 9. (Optional) DAP Configuration Placeholders
+        -- 10. (Optional) DAP Configuration Placeholders
         -- --------------------------------------------------------------------
         -- -- Configure DAP bucket
         -- -- Configure mason-nvim-dap Debuggers

--- a/nvim/lua/nairovim/plugins/telescope.lua
+++ b/nvim/lua/nairovim/plugins/telescope.lua
@@ -7,7 +7,12 @@ return {
     branch = "0.1.x",
     dependencies = {
         { "nvim-lua/plenary.nvim" },
-        { "nvim-telescope/telescope-fzf-native.nvim", build = "make" },
+        {
+            "nvim-telescope/telescope-fzf-native.nvim",
+            build = vim.fn.has("win32") == 1
+                    and "cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release"
+                    or "make",
+        },
     },
     config = function()
         ----------------------------------------------------------------------

--- a/nvim/lua/nairovim/plugins/treesitter.lua
+++ b/nvim/lua/nairovim/plugins/treesitter.lua
@@ -18,6 +18,14 @@ return {
     "nvim-treesitter/nvim-treesitter",
     event = { "BufReadPre", "BufNewFile" },
     build = function()
+        -- Windows-specific: Ensure MinGW is in PATH
+        if vim.fn.has("win32") == 1 then
+            local require_ok, ts_install = pcall(require, "nvim-treesitter.install")
+            if require_ok then
+                ts_install.compilers = { "gcc", "clang", "cl", "cc" }
+            end
+        end
+        
         local ts_update = require("nvim-treesitter.install").update({ with_sync = true })
         ts_update()
     end,

--- a/nvim/lua/nairovim/plugins/treesitter.lua
+++ b/nvim/lua/nairovim/plugins/treesitter.lua
@@ -16,25 +16,15 @@ vim.api.nvim_create_autocmd({ "FileType" }, {
 ----------------------------------------------------------------------
 return {
     "nvim-treesitter/nvim-treesitter",
+    branch = "master", -- Use stable master branch (old API)
     event = { "BufReadPre", "BufNewFile" },
-    build = function()
-        -- Windows-specific: Ensure MinGW is in PATH
-        if vim.fn.has("win32") == 1 then
-            local require_ok, ts_install = pcall(require, "nvim-treesitter.install")
-            if require_ok then
-                ts_install.compilers = { "gcc", "clang", "cl", "cc" }
-            end
-        end
-        
-        local ts_update = require("nvim-treesitter.install").update({ with_sync = true })
-        ts_update()
-    end,
+    build = ":TSUpdate",
     dependencies = {
         "windwp/nvim-ts-autotag",
     },
     config = function()
         ----------------------------------------------------------------------
-        -- 3. Treesitter Core Configuration
+        -- 3. Treesitter Core Configuration (Old API)
         ----------------------------------------------------------------------
         require("nvim-treesitter.configs").setup({
             highlight = { enable = true },
@@ -46,6 +36,7 @@ return {
                 "tsx",
                 "lua",
                 "vim",
+                "vimdoc",
                 "css",
                 "html",
                 "markdown",

--- a/windows-terminal-settings.json
+++ b/windows-terminal-settings.json
@@ -1,0 +1,257 @@
+{
+    "$help": "https://aka.ms/terminal-documentation",
+    "$schema": "https://aka.ms/terminal-profiles-schema",
+    "actions": [
+        {
+            "command": "find",
+            "keys": "ctrl+shift+f"
+        },
+        {
+            "command": {
+                "action": "splitPane",
+                "split": "down"
+            },
+            "keys": "ctrl+b|-"
+        },
+        {
+            "command": {
+                "action": "splitPane",
+                "split": "right"
+            },
+            "keys": "ctrl+b|="
+        },
+        {
+            "command": {
+                "action": "resizePane",
+                "direction": "down"
+            },
+            "keys": "ctrl+b|v"
+        },
+        {
+            "command": {
+                "action": "resizePane",
+                "direction": "up"
+            },
+            "keys": "ctrl+b|shift+6"
+        },
+        {
+            "command": {
+                "action": "resizePane",
+                "direction": "left"
+            },
+            "keys": "ctrl+b|,"
+        },
+        {
+            "command": {
+                "action": "resizePane",
+                "direction": "right"
+            },
+            "keys": "ctrl+b|."
+        },
+        {
+            "command": {
+                "action": "moveFocus",
+                "direction": "down"
+            },
+            "keys": "ctrl+b|j"
+        },
+        {
+            "command": {
+                "action": "moveFocus",
+                "direction": "up"
+            },
+            "keys": "ctrl+b|k"
+        },
+        {
+            "command": {
+                "action": "moveFocus",
+                "direction": "right"
+            },
+            "keys": "ctrl+b|l"
+        },
+        {
+            "command": {
+                "action": "moveFocus",
+                "direction": "left"
+            },
+            "keys": "ctrl+b|h"
+        },
+        {
+            "command": "togglePaneZoom",
+            "keys": "ctrl+b|z"
+        },
+        {
+            "command": {
+                "action": "newTab"
+            },
+            "keys": "ctrl+b|c"
+        },
+        {
+            "command": {
+                "action": "nextTab"
+            },
+            "keys": "ctrl+b|n"
+        },
+        {
+            "command": {
+                "action": "prevTab"
+            },
+            "keys": "ctrl+b|p"
+        },
+        {
+            "command": "closePane",
+            "keys": "ctrl+b|x"
+        },
+        {
+            "command": "paste",
+            "keys": "ctrl+v"
+        },
+        {
+            "command": "copy",
+            "keys": "ctrl+shift+c"
+        }
+    ],
+    "copyFormatting": "none",
+    "copyOnSelect": false,
+    "defaultProfile": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
+    "newTabMenu": [
+        {
+            "type": "remainingProfiles"
+        }
+    ],
+    "profiles": {
+        "defaults": {
+            "colorScheme": "TokyoNight",
+            "font": {
+                "face": "JetBrainsMono Nerd Font Mono",
+                "size": 11.0
+            },
+            "opacity": 95,
+            "padding": "8, 8, 8, 8",
+            "useAcrylic": false
+        },
+        "list": [
+            {
+                "commandline": "%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                "guid": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
+                "hidden": false,
+                "name": "Windows PowerShell"
+            },
+            {
+                "commandline": "%SystemRoot%\\System32\\cmd.exe",
+                "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
+                "hidden": false,
+                "name": "Command Prompt"
+            },
+            {
+                "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+                "hidden": false,
+                "name": "PowerShell 7",
+                "source": "Windows.Terminal.PowershellCore"
+            },
+            {
+                "guid": "{2c4de342-38b7-51cf-b940-2309a097f518}",
+                "hidden": false,
+                "name": "Ubuntu",
+                "source": "Windows.Terminal.Wsl"
+            }
+        ]
+    },
+    "schemes": [
+        {
+            "name": "TokyoNight",
+            "background": "#1a1b26",
+            "foreground": "#c0caf5",
+            "cursorColor": "#c0caf5",
+            "selectionBackground": "#283457",
+            "black": "#15161e",
+            "red": "#f7768e",
+            "green": "#9ece6a",
+            "yellow": "#e0af68",
+            "blue": "#7aa2f7",
+            "purple": "#bb9af7",
+            "cyan": "#7dcfff",
+            "white": "#a9b1d6",
+            "brightBlack": "#414868",
+            "brightRed": "#f7768e",
+            "brightGreen": "#9ece6a",
+            "brightYellow": "#e0af68",
+            "brightBlue": "#7aa2f7",
+            "brightPurple": "#bb9af7",
+            "brightCyan": "#7dcfff",
+            "brightWhite": "#c0caf5"
+        },
+        {
+            "name": "TokyoNight Day",
+            "background": "#e1e2e7",
+            "foreground": "#3760bf",
+            "cursorColor": "#3760bf",
+            "selectionBackground": "#b6bfe2",
+            "black": "#e9e9ed",
+            "red": "#f52a65",
+            "green": "#587539",
+            "yellow": "#8c6c3e",
+            "blue": "#2e7de9",
+            "purple": "#9854f1",
+            "cyan": "#007197",
+            "white": "#6172b0",
+            "brightBlack": "#a1a6c5",
+            "brightRed": "#f52a65",
+            "brightGreen": "#587539",
+            "brightYellow": "#8c6c3e",
+            "brightBlue": "#2e7de9",
+            "brightPurple": "#9854f1",
+            "brightCyan": "#007197",
+            "brightWhite": "#3760bf"
+        },
+        {
+            "name": "Gruvbox Dark",
+            "background": "#282828",
+            "foreground": "#ebdbb2",
+            "cursorColor": "#ebdbb2",
+            "selectionBackground": "#504945",
+            "black": "#282828",
+            "red": "#cc241d",
+            "green": "#98971a",
+            "yellow": "#d79921",
+            "blue": "#458588",
+            "purple": "#b16286",
+            "cyan": "#689d6a",
+            "white": "#a89984",
+            "brightBlack": "#928374",
+            "brightRed": "#fb4934",
+            "brightGreen": "#b8bb26",
+            "brightYellow": "#fabd2f",
+            "brightBlue": "#83a598",
+            "brightPurple": "#d3869b",
+            "brightCyan": "#8ec07c",
+            "brightWhite": "#ebdbb2"
+        },
+        {
+            "name": "Gruvbox Light",
+            "background": "#fbf1c7",
+            "foreground": "#3c3836",
+            "cursorColor": "#3c3836",
+            "selectionBackground": "#d5c4a1",
+            "black": "#fbf1c7",
+            "red": "#cc241d",
+            "green": "#98971a",
+            "yellow": "#d79921",
+            "blue": "#458588",
+            "purple": "#b16286",
+            "cyan": "#689d6a",
+            "white": "#7c6f64",
+            "brightBlack": "#928374",
+            "brightRed": "#9d0006",
+            "brightGreen": "#79740e",
+            "brightYellow": "#b57614",
+            "brightBlue": "#076678",
+            "brightPurple": "#8f3f71",
+            "brightCyan": "#427b58",
+            "brightWhite": "#3c3836"
+        }
+    ],
+    "theme": "system",
+    "themes": [],
+    "useAcrylicInTabRow": false
+}

--- a/windows-terminal-settings.json
+++ b/windows-terminal-settings.json
@@ -4,133 +4,214 @@
     "actions": [
         {
             "command": "find",
-            "keys": "ctrl+shift+f"
+            "id": "User.FindText"
         },
         {
             "command": {
                 "action": "splitPane",
                 "split": "down"
             },
-            "keys": "ctrl+b|-"
+            "id": "User.SplitPaneDown"
         },
         {
             "command": {
                 "action": "splitPane",
                 "split": "right"
             },
-            "keys": "ctrl+b|="
+            "id": "User.SplitPaneRight"
         },
         {
             "command": {
                 "action": "resizePane",
                 "direction": "down"
             },
-            "keys": "ctrl+b|v"
+            "id": "User.ResizePaneDown"
         },
         {
             "command": {
                 "action": "resizePane",
                 "direction": "up"
             },
-            "keys": "ctrl+b|shift+6"
+            "id": "User.ResizePaneUp"
         },
         {
             "command": {
                 "action": "resizePane",
                 "direction": "left"
             },
-            "keys": "ctrl+b|,"
+            "id": "User.ResizePaneLeft"
         },
         {
             "command": {
                 "action": "resizePane",
                 "direction": "right"
             },
-            "keys": "ctrl+b|."
+            "id": "User.ResizePaneRight"
         },
         {
             "command": {
                 "action": "moveFocus",
                 "direction": "down"
             },
-            "keys": "ctrl+b|j"
+            "id": "User.MoveFocusDown"
         },
         {
             "command": {
                 "action": "moveFocus",
                 "direction": "up"
             },
-            "keys": "ctrl+b|k"
+            "id": "User.MoveFocusUp"
         },
         {
             "command": {
                 "action": "moveFocus",
                 "direction": "right"
             },
-            "keys": "ctrl+b|l"
+            "id": "User.MoveFocusRight"
         },
         {
             "command": {
                 "action": "moveFocus",
                 "direction": "left"
             },
-            "keys": "ctrl+b|h"
+            "id": "User.MoveFocusLeft"
         },
         {
             "command": "togglePaneZoom",
-            "keys": "ctrl+b|z"
+            "id": "User.TogglePaneZoom"
         },
         {
             "command": {
                 "action": "newTab"
             },
-            "keys": "ctrl+b|c"
+            "id": "User.NewTab"
         },
         {
             "command": {
                 "action": "nextTab"
             },
-            "keys": "ctrl+b|n"
+            "id": "User.NextTab"
         },
         {
             "command": {
                 "action": "prevTab"
             },
-            "keys": "ctrl+b|p"
+            "id": "User.PrevTab"
         },
         {
             "command": "closePane",
-            "keys": "ctrl+b|x"
+            "id": "User.ClosePane"
         },
         {
             "command": "paste",
-            "keys": "ctrl+v"
+            "id": "User.Paste"
         },
         {
             "command": "copy",
-            "keys": "ctrl+shift+c"
+            "id": "User.Copy"
         }
     ],
     "copyFormatting": "none",
     "copyOnSelect": false,
-    "defaultProfile": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
-    "newTabMenu": [
+    "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+    "keybindings": 
+    [
+        {
+            "keys": "ctrl+shift+f",
+            "id": "User.FindText"
+        },
+        {
+            "keys": "ctrl+alt+minus",
+            "id": "User.SplitPaneDown"
+        },
+        {
+            "keys": "ctrl+alt+plus",
+            "id": "User.SplitPaneRight"
+        },
+        {
+            "keys": "ctrl+alt+down",
+            "id": "User.ResizePaneDown"
+        },
+        {
+            "keys": "ctrl+alt+up",
+            "id": "User.ResizePaneUp"
+        },
+        {
+            "keys": "ctrl+alt+left",
+            "id": "User.ResizePaneLeft"
+        },
+        {
+            "keys": "ctrl+alt+right",
+            "id": "User.ResizePaneRight"
+        },
+        {
+            "keys": "alt+j",
+            "id": "User.MoveFocusDown"
+        },
+        {
+            "keys": "alt+k",
+            "id": "User.MoveFocusUp"
+        },
+        {
+            "keys": "alt+l",
+            "id": "User.MoveFocusRight"
+        },
+        {
+            "keys": "alt+h",
+            "id": "User.MoveFocusLeft"
+        },
+        {
+            "keys": "ctrl+alt+z",
+            "id": "User.TogglePaneZoom"
+        },
+        {
+            "keys": "ctrl+alt+c",
+            "id": "User.NewTab"
+        },
+        {
+            "keys": "ctrl+alt+n",
+            "id": "User.NextTab"
+        },
+        {
+            "keys": "ctrl+alt+p",
+            "id": "User.PrevTab"
+        },
+        {
+            "keys": "ctrl+alt+x",
+            "id": "User.ClosePane"
+        },
+        {
+            "keys": "ctrl+v",
+            "id": "User.Paste"
+        },
+        {
+            "keys": "ctrl+shift+c",
+            "id": "User.Copy"
+        }
+    ],
+    "newTabMenu": 
+    [
         {
             "type": "remainingProfiles"
         }
     ],
-    "profiles": {
-        "defaults": {
+    "profiles": 
+    {
+        "defaults": 
+        {
             "colorScheme": "TokyoNight",
-            "font": {
+            "font": 
+            {
                 "face": "JetBrainsMono Nerd Font Mono",
-                "size": 11.0
+                "size": 9
             },
             "opacity": 95,
-            "padding": "8, 8, 8, 8",
+            "padding": "4,0,0,0",
+            "scrollbarState": "hidden",
             "useAcrylic": false
         },
-        "list": [
+        "list": 
+        [
             {
                 "commandline": "%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
                 "guid": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
@@ -150,105 +231,106 @@
                 "source": "Windows.Terminal.PowershellCore"
             },
             {
-                "guid": "{2c4de342-38b7-51cf-b940-2309a097f518}",
-                "hidden": false,
-                "name": "Ubuntu",
-                "source": "Windows.Terminal.Wsl"
+                "guid": "{16208362-94fc-5b1f-a491-5b2624d5ab56}",
+                "hidden": true,
+                "name": "Visual Studio Debug Console",
+                "source": "VSDebugConsole"
             }
         ]
     },
-    "schemes": [
+    "schemes": 
+    [
         {
-            "name": "TokyoNight",
-            "background": "#1a1b26",
-            "foreground": "#c0caf5",
-            "cursorColor": "#c0caf5",
-            "selectionBackground": "#283457",
-            "black": "#15161e",
-            "red": "#f7768e",
-            "green": "#9ece6a",
-            "yellow": "#e0af68",
-            "blue": "#7aa2f7",
-            "purple": "#bb9af7",
-            "cyan": "#7dcfff",
-            "white": "#a9b1d6",
-            "brightBlack": "#414868",
-            "brightRed": "#f7768e",
-            "brightGreen": "#9ece6a",
-            "brightYellow": "#e0af68",
-            "brightBlue": "#7aa2f7",
-            "brightPurple": "#bb9af7",
-            "brightCyan": "#7dcfff",
-            "brightWhite": "#c0caf5"
-        },
-        {
-            "name": "TokyoNight Day",
-            "background": "#e1e2e7",
-            "foreground": "#3760bf",
-            "cursorColor": "#3760bf",
-            "selectionBackground": "#b6bfe2",
-            "black": "#e9e9ed",
-            "red": "#f52a65",
-            "green": "#587539",
-            "yellow": "#8c6c3e",
-            "blue": "#2e7de9",
-            "purple": "#9854f1",
-            "cyan": "#007197",
-            "white": "#6172b0",
-            "brightBlack": "#a1a6c5",
-            "brightRed": "#f52a65",
-            "brightGreen": "#587539",
-            "brightYellow": "#8c6c3e",
-            "brightBlue": "#2e7de9",
-            "brightPurple": "#9854f1",
-            "brightCyan": "#007197",
-            "brightWhite": "#3760bf"
-        },
-        {
-            "name": "Gruvbox Dark",
             "background": "#282828",
-            "foreground": "#ebdbb2",
-            "cursorColor": "#ebdbb2",
-            "selectionBackground": "#504945",
             "black": "#282828",
-            "red": "#cc241d",
-            "green": "#98971a",
-            "yellow": "#d79921",
             "blue": "#458588",
-            "purple": "#b16286",
-            "cyan": "#689d6a",
-            "white": "#a89984",
             "brightBlack": "#928374",
-            "brightRed": "#fb4934",
-            "brightGreen": "#b8bb26",
-            "brightYellow": "#fabd2f",
-            "brightBlue": "#83a598",
-            "brightPurple": "#d3869b",
-            "brightCyan": "#8ec07c",
-            "brightWhite": "#ebdbb2"
+            "brightBlue": "#83A598",
+            "brightCyan": "#8EC07C",
+            "brightGreen": "#B8BB26",
+            "brightPurple": "#D3869B",
+            "brightRed": "#FB4934",
+            "brightWhite": "#EBDBB2",
+            "brightYellow": "#FABD2F",
+            "cursorColor": "#EBDBB2",
+            "cyan": "#689D6A",
+            "foreground": "#EBDBB2",
+            "green": "#98971A",
+            "name": "Gruvbox Dark",
+            "purple": "#B16286",
+            "red": "#CC241D",
+            "selectionBackground": "#504945",
+            "white": "#A89984",
+            "yellow": "#D79921"
         },
         {
-            "name": "Gruvbox Light",
-            "background": "#fbf1c7",
-            "foreground": "#3c3836",
-            "cursorColor": "#3c3836",
-            "selectionBackground": "#d5c4a1",
-            "black": "#fbf1c7",
-            "red": "#cc241d",
-            "green": "#98971a",
-            "yellow": "#d79921",
+            "background": "#FBF1C7",
+            "black": "#FBF1C7",
             "blue": "#458588",
-            "purple": "#b16286",
-            "cyan": "#689d6a",
-            "white": "#7c6f64",
             "brightBlack": "#928374",
-            "brightRed": "#9d0006",
-            "brightGreen": "#79740e",
-            "brightYellow": "#b57614",
             "brightBlue": "#076678",
-            "brightPurple": "#8f3f71",
-            "brightCyan": "#427b58",
-            "brightWhite": "#3c3836"
+            "brightCyan": "#427B58",
+            "brightGreen": "#79740E",
+            "brightPurple": "#8F3F71",
+            "brightRed": "#9D0006",
+            "brightWhite": "#3C3836",
+            "brightYellow": "#B57614",
+            "cursorColor": "#3C3836",
+            "cyan": "#689D6A",
+            "foreground": "#3C3836",
+            "green": "#98971A",
+            "name": "Gruvbox Light",
+            "purple": "#B16286",
+            "red": "#CC241D",
+            "selectionBackground": "#D5C4A1",
+            "white": "#7C6F64",
+            "yellow": "#D79921"
+        },
+        {
+            "background": "#1A1B26",
+            "black": "#15161E",
+            "blue": "#7AA2F7",
+            "brightBlack": "#414868",
+            "brightBlue": "#7AA2F7",
+            "brightCyan": "#7DCFFF",
+            "brightGreen": "#9ECE6A",
+            "brightPurple": "#BB9AF7",
+            "brightRed": "#F7768E",
+            "brightWhite": "#C0CAF5",
+            "brightYellow": "#E0AF68",
+            "cursorColor": "#C0CAF5",
+            "cyan": "#7DCFFF",
+            "foreground": "#C0CAF5",
+            "green": "#9ECE6A",
+            "name": "TokyoNight",
+            "purple": "#BB9AF7",
+            "red": "#F7768E",
+            "selectionBackground": "#283457",
+            "white": "#A9B1D6",
+            "yellow": "#E0AF68"
+        },
+        {
+            "background": "#E1E2E7",
+            "black": "#E9E9ED",
+            "blue": "#2E7DE9",
+            "brightBlack": "#A1A6C5",
+            "brightBlue": "#2E7DE9",
+            "brightCyan": "#007197",
+            "brightGreen": "#587539",
+            "brightPurple": "#9854F1",
+            "brightRed": "#F52A65",
+            "brightWhite": "#3760BF",
+            "brightYellow": "#8C6C3E",
+            "cursorColor": "#3760BF",
+            "cyan": "#007197",
+            "foreground": "#3760BF",
+            "green": "#587539",
+            "name": "TokyoNight Day",
+            "purple": "#9854F1",
+            "red": "#F52A65",
+            "selectionBackground": "#B6BFE2",
+            "white": "#6172B0",
+            "yellow": "#8C6C3E"
         }
     ],
     "theme": "system",


### PR DESCRIPTION
## What does this PR do?

Fixes critical bug in install.sh where `print_step` function fails with "unbound variable" error when called with only one argument.

- Made second parameter of `print_step()` optional
- Added conditional logic to display description only when provided
- Prevents script failure at lines 286 and 397

## Why is it needed?

The `set -euo pipefail` option causes the script to fail when `$2` is referenced but not provided. Two calls to `print_step` only pass one argument, breaking the installation process.

## How have the changes been tested?

- Verified function works with one argument
- Verified function works with two arguments
- Tested on bash with `set -euo pipefail` enabled

## Checklist

- [x] Bug fix applied to print_step function
- [x] Tested with one and two arguments
- [x] Script runs without unbound variable error