### PR TITLE
2025-02-03: Fix install.sh unbound variable error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -60,7 +60,12 @@ print_section() {
 
 # Print step with icon
 print_step() {
-    echo "${cyan}${HOURGLASS} ${bold}$1${textreset} ${dim}$2${textreset}"
+    local description="${2:-}"  # Make second parameter optional
+    if [[ -n "$description" ]]; then
+        echo "${cyan}${HOURGLASS} ${bold}$1${textreset} ${dim}$description${textreset}"
+    else
+        echo "${cyan}${HOURGLASS} ${bold}$1${textreset}"
+    fi
 }
 
 # Print success message


### PR DESCRIPTION
## What does this PR do?

Fixes critical bug in install.sh where `print_step` function fails with "unbound variable" error when called with only one argument.

- Made second parameter of `print_step()` optional
- Added conditional logic to display description only when provided

## Why is it needed?

The `set -euo pipefail` option causes the script to fail when `$2` is referenced but not provided. Two calls to `print_step` only pass one argument, breaking the installation process.

## How have the changes been tested?

- Verified function works with one argument
- Verified function works with two arguments
- Tested on bash with `set -euo pipefail` enabled

## Checklist

- [x] Bug fix applied to print_step function
- [x] Tested with one and two arguments
- [x] Script runs without unbound variable error