### PR TITLE
2025-02-03: Fix install.sh to check zsh before installing Oh My Zsh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -502,6 +502,12 @@ install_tmux() {
 install_oh_my_zsh() {
     print_section "${SPARKLES} Installing Oh My Zsh"
 
+    # Check if zsh is installed first
+    if ! command_exists zsh; then
+        print_step "Installing zsh" "required for Oh My Zsh"
+        install_with_brew "zsh" "Zsh shell"
+    fi
+
     local oh_my_zsh_dir="$HOME/.oh-my-zsh"
 
     if [[ -d "$oh_my_zsh_dir" ]]; then


### PR DESCRIPTION
## What does this PR do?

Fixes installation failure when zsh is not installed before attempting to install Oh My Zsh.

- Added zsh installation check before installing Oh My Zsh
- Automatically installs zsh via Homebrew if missing

## Why is it needed?

Oh My Zsh requires zsh to be installed first. The script was failing with "Zsh is not installed" error when attempting to install Oh My Zsh on systems without zsh.

## How have the changes been tested?

- Verified zsh installation check works correctly
- Tested on system without zsh (auto-installs zsh)
- Tested on system with zsh (skips installation)

## Checklist

- [x] Added zsh check before Oh My Zsh installation
- [x] Uses existing install_with_brew function
- [x] Prevents installation failure