### PR TITLE
2026-02-14: NvimTree Dynamic Width with Min/Max Bounds

### DIFF
--- a/nvim/lua/nairovim/plugins/nvim-tree.lua
+++ b/nvim/lua/nairovim/plugins/nvim-tree.lua
@@ -29,7 +29,10 @@ return {
                 git_ignored = true,
             },
             view = {
-                width = 50,
+                width = {
+                    min = 30,
+                    max = 50,
+                },
             },
             renderer = {
                 indent_markers = {


### PR DESCRIPTION
## What does this PR do?

Replace NvimTree's fixed 50-column width with dynamic content-based sizing, clamped between 30 and 50 columns.

- Replace fixed `width = 50` with a `width` table using `min = 30` and `max = 50`
- Tree panel now adapts to the longest visible filename within the defined bounds

## Why is it needed?

A fixed width wastes space on narrow trees and truncates long filenames. Dynamic sizing with min/max bounds provides a better balance between screen real estate and readability.

## How have the changes been tested?

- Verified NvimTree opens and resizes dynamically within the 30–50 column range

## Checklist

- [x] Config change follows lazy.nvim plugin spec format
- [x] No unrelated changes included