### PR TITLE
2026-02-26: Fix MarkdownPreview on WSL and Windows

### DIFF
--- a/nvim/lua/nairovim/plugins/init.lua
+++ b/nvim/lua/nairovim/plugins/init.lua
@@ -60,8 +60,24 @@ return {
             "iamcco/markdown-preview.nvim",
             cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
             ft = { "markdown" },
-            build = function()
-                vim.fn["mkdp#util#install"]()
+            build = "cd app && npx --yes yarn install",
+            init = function()
+                vim.g.mkdp_echo_preview_url = 1
+                if vim.fn.has("wsl") == 1 then
+                    vim.g.mkdp_browserfunc = "MkdpOpenBrowser"
+                    vim.cmd([[
+                        function! MkdpOpenBrowser(url)
+                            silent execute '!wslview ' . shellescape(a:url) . ' &'
+                        endfunction
+                    ]])
+                elseif vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1 then
+                    vim.g.mkdp_browserfunc = "MkdpOpenBrowser"
+                    vim.cmd([[
+                        function! MkdpOpenBrowser(url)
+                            silent execute '!start "" ' . shellescape(a:url)
+                        endfunction
+                    ]])
+                end
             end,
         },
         {


### PR DESCRIPTION
## What does this PR do?

Fix `:MarkdownPreview` command failing silently on WSL and Windows (only worked on macOS).

- Replace `mkdp#util#install()` build step with `cd app && npx --yes yarn install` for reliable cross-platform server installation via Node.js
- Add `mkdp_browserfunc` with platform-specific browser launchers that bypass the plugin's broken `opener.js`:
  - **WSL**: `wslview` called directly from shell
  - **Windows**: `start` command via native shell
  - **macOS**: unchanged (default `open` works)
- Enable `mkdp_echo_preview_url` for preview URL visibility in command line
- Use `shellescape()` for proper URL escaping

## Why is it needed?

The plugin's binary download build step (`mkdp#util#install()`) failed silently, leaving no server binary installed. Additionally, the plugin's built-in `opener.js` browser launcher couldn't open browsers correctly on WSL (broken `cmd.exe` interop) or Windows (PowerShell shell conflicts).

## How have the changes been tested?

- Verified `:MarkdownPreview` opens the Windows default browser from WSL
- Windows and macOS testing pending

## Checklist

- [x] Build step works with Node.js v22 on WSL
- [x] `wslview` browser launch tested on WSL
- [ ] `start` command browser launch tested on Windows native
- [ ] Default `open` still works on macOS