### PR TITLE
2026-02-26: Fix markdown-preview.nvim build on Windows

### DIFF
--- a/nvim/lua/nairovim/plugins/init.lua
+++ b/nvim/lua/nairovim/plugins/init.lua
@@ -63,7 +63,23 @@ return {
             build = function(plugin)
                 local app_dir = plugin.dir .. "/app"
                 if vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1 then
-                    vim.system({ "cmd.exe", "/c", "install.cmd" }, { cwd = app_dir }):wait()
+                    local bin_dir = app_dir .. "/bin"
+                    vim.fn.mkdir(bin_dir, "p")
+                    local zip = bin_dir .. "/markdown-preview-win.zip"
+                    vim.system({
+                        "curl",
+                        "-sL",
+                        "-o",
+                        zip,
+                        "https://github.com/iamcco/markdown-preview.nvim/releases/latest/download/markdown-preview-win.zip",
+                    }):wait()
+                    vim.system({
+                        "powershell",
+                        "-NoProfile",
+                        "-Command",
+                        "Expand-Archive -Path '" .. zip .. "' -DestinationPath '" .. bin_dir .. "' -Force",
+                    }):wait()
+                    os.remove(zip)
                 else
                     vim.system({ "bash", "install.sh" }, { cwd = app_dir }):wait()
                 end


### PR DESCRIPTION
## What does this PR do?

Fix the markdown-preview.nvim plugin build step which silently fails on Windows, preventing `:MarkdownPreview` from working.

- Replace the broken `install.cmd` invocation with direct `curl` download and PowerShell `Expand-Archive` extraction of the pre-built binary
- Unix/WSL build path (`install.sh`) remains unchanged

## Why is it needed?

The bundled `install.cmd` script fails on Windows because its PowerShell `Invoke-WebRequest` call cannot parse the GitHub releases API response to determine the latest release tag. This results in an empty tag, a malformed download URL, and a 404 — leaving `app/bin/` empty and the plugin non-functional.

## How have the changes been tested?

- Ran `:Lazy build markdown-preview.nvim` on Windows — binary downloaded and extracted to `app/bin/markdown-preview-win.exe`
- Ran `:MarkdownPreview` — preview opened in browser successfully

## Checklist

- [x] Build step works on Windows (curl + Expand-Archive)
- [x] Build step works on Unix/WSL (install.sh unchanged)
- [x] `:MarkdownPreview` opens browser on Windows