### PR TITLE
2026-03-01: Add sidekick.nvim with platform-aware dashboard integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ nvim/plugin/packer_compiled.lua
 # Node.js dependencies for commitizen
 node_modules/
 package-lock.json
+
+# Zellij tarball (not used by install scripts)
+zellij-*.tar.gz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,17 +7,17 @@ High-level overview of development tasks for AI agents.
 ## 2026-02-28: Sidekick Plugin Configuration & Keymap Refactoring
 **Goal:** Add complete sidekick.nvim plugin configuration with clean keymap organization
 
-Implemented full sidekick.nvim configuration with zellij backend, tool-specific overrides, and extracted all keymaps to dedicated customizations file following project conventions. Part of the broader OpenCode Ctrl+P fix initiative.
+Implemented full sidekick.nvim configuration with platform-specific multiplexer backend (psmux on Windows, zellij on macOS/Linux), tool-specific overrides, and extracted all keymaps to dedicated customizations file following project conventions. Part of the broader OpenCode Ctrl+P fix initiative.
 
 **Configuration Components:**
 
-1. **Multiplexer Backend** (zellij):
-   - Preferred over tmux to avoid colorscheme rendering issues
-   - Enabled with `mux.backend = "zellij"`
-   - Full multiplexer session support
-   - **Windows Compatibility**: Disabled on Windows native (`enabled = vim.fn.has("win32") == 0`)
-   - Zellij has no Windows native build, only Linux/macOS binaries
-   - WSL users still get full zellij support
+1. **Multiplexer Backend** (platform-specific):
+   - **Windows**: Uses tmux backend (provided by psmux installation)
+   - **macOS/Linux**: Uses zellij backend (preferred to avoid tmux colorscheme issues)
+   - **Detection**: `vim.fn.has("win32") == 1 and "tmux" or "zellij"`
+   - **psmux**: Native Windows terminal multiplexer in Rust, 100% tmux-compatible
+   - Installs `psmux`, `pmux`, and `tmux` binaries (sidekick detects `tmux` on PATH)
+   - Full multiplexer session support on all platforms
 
 2. **Terminal Window Layout**:
    - Position: Right side of screen (`layout = "right"`)
@@ -79,7 +79,7 @@ nvim/lua/nairovim/plugins/
 **Branch:** `feat/sidekick-ctrl-p-fix`  
 **Files:** 2 new files (sidekick.lua, keymaps/sidekick.lua)  
 **Line changes:** +152 lines total  
-**Commits:** 4 commits (plugin config, lazy-lock update, Windows compatibility fix, install script fix)
+**Commits:** 6 commits (plugin config, lazy-lock update, zellij install, docs, psmux switch, psmux install)
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,70 @@ High-level overview of development tasks for AI agents.
 
 ---
 
+## 2026-02-28: Platform-Aware Dashboard AI Entries
+**Goal:** Add Agency CLI to Snacks dashboard with platform-specific ordering
+
+Refactored Snacks dashboard to display both OpenCode and Agency CLI with platform-aware prioritization. Windows shows OpenCode as preferred (stable), macOS/Linux shows Agency CLI as preferred (since it can launch OpenCode via sidekick tool picker).
+
+**Platform-Specific Entries:**
+
+1. **Windows Dashboard:**
+   - `O` → OpenCode (Preferred) - Direct toggle, stable on Windows
+   - `A` → Agency CLI (Preview) - Opens sidekick tool picker, preview status
+
+2. **macOS/Linux Dashboard:**
+   - `A` → Agency CLI (Preferred) - Opens sidekick tool picker (can launch OpenCode)
+   - `O` → OpenCode - Direct toggle, secondary option
+
+**Implementation Details:**
+
+- **Structure**: Keys table split into three parts (`keys_before`, `ai_entries`, `keys_after`) merged with `vim.list_extend`
+- **Platform Detection**: `vim.fn.has("win32") == 1` determines which entry set to use
+- **Icons**: Both use ` ` (AI/robot icon) for visual consistency
+- **Actions**:
+  - OpenCode: `:lua require('opencode').toggle()` (direct toggle)
+  - Agency CLI: `:lua require('sidekick.cli').select()` (tool picker)
+- **IIFE Pattern**: Dashboard keys use immediately-invoked function expression to build dynamic array
+
+**Why Agency CLI Primary on macOS/Linux:**
+- Sidekick tool picker provides access to ALL AI tools (OpenCode, Claude, Copilot, etc.)
+- Can launch OpenCode from within sidekick if needed
+- More flexible entry point for multi-tool workflows
+- Works better with zellij backend (no colorscheme issues)
+
+**Why OpenCode Primary on Windows:**
+- More stable/mature on Windows platform
+- Agency CLI marked as "Preview" due to psmux limitations (scrolling, newline, set-option issues)
+- Direct OpenCode toggle provides immediate access to stable tool
+
+**Code Pattern:**
+
+```lua
+keys = (function()
+    local keys_before = { -- f, n, t, F, g, r, G entries -- }
+    
+    local ai_entries = vim.fn.has("win32") == 1 and {
+        { icon = " ", key = "O", desc = "OpenCode (Preferred)", ... },
+        { icon = " ", key = "A", desc = "Agency CLI (Preview)", ... },
+    } or {
+        { icon = " ", key = "A", desc = "Agency CLI (Preferred)", ... },
+        { icon = " ", key = "O", desc = "OpenCode", ... },
+    }
+    
+    local keys_after = { -- l, c, s, m, q entries -- }
+    
+    return vim.list_extend(vim.list_extend(keys_before, ai_entries), keys_after)
+end)(),
+```
+
+**Impact:** Users see preferred AI tool first, both tools accessible via single key, platform-appropriate recommendations  
+**Branch:** `feat/sidekick-ctrl-p-fix`  
+**Files:** 1 file modified (snacks.lua)  
+**Line changes:** +81, -51 (139 lines total, was 109)  
+**Commit:** `82f0ef1`
+
+---
+
 ## 2026-02-28: Sidekick Plugin Configuration & Keymap Refactoring
 **Goal:** Add complete sidekick.nvim plugin configuration with clean keymap organization
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,160 @@ High-level overview of development tasks for AI agents.
 
 ---
 
+## 2026-02-28: Sidekick Plugin Configuration & Keymap Refactoring
+**Goal:** Add complete sidekick.nvim plugin configuration with clean keymap organization
+
+Implemented full sidekick.nvim configuration with zellij backend, tool-specific overrides, and extracted all keymaps to dedicated customizations file following project conventions. Part of the broader OpenCode Ctrl+P fix initiative.
+
+**Configuration Components:**
+
+1. **Multiplexer Backend** (zellij):
+   - Preferred over tmux to avoid colorscheme rendering issues
+   - Enabled with `mux.backend = "zellij"`
+   - Full multiplexer session support
+
+2. **Terminal Window Layout**:
+   - Position: Right side of screen (`layout = "right"`)
+   - Width: 45% of screen (`split.width = 0.45`)
+   - Height: Full height auto-calculated (`split.height = 0`)
+   - Matches OpenCode terminal dimensions for consistency
+
+3. **Tool-Specific Overrides**:
+   - **OpenCode**: Alt+P for sidekick prompt (frees Ctrl+P for OpenCode's command list)
+   - **Copilot**: Ctrl+S for submit/send (custom keybinding for terminal interaction)
+
+4. **Keymap Organization**:
+   - Extracted all 10 keybindings to `customizations/keymaps/sidekick.lua`
+   - Converted from lazy.nvim `keys` table to `nairovim.KeymapDef[]` format
+   - Loaded via `common.map()` utility in plugin `config` function
+   - Maintains consistency with other plugin keymaps (telescope, opencode, lazygit, etc.)
+
+**Keybindings Included:**
+
+| Key | Mode | Action | Description |
+|-----|------|--------|-------------|
+| `<tab>` | n | `nes_jump_or_apply()` | Next Edit Suggestion jump/apply |
+| `<c-.>` | n,t,i,x | `toggle()` | Toggle sidekick CLI |
+| `<leader>aa` | n | `toggle()` | Toggle sidekick CLI (mnemonic) |
+| `<leader>as` | n | `select()` | Select CLI tool |
+| `<leader>ad` | n | `close()` | Detach/close session |
+| `<leader>at` | n,x | `send({ msg = "{this}" })` | Send current context |
+| `<leader>af` | n | `send({ msg = "{file}" })` | Send entire file |
+| `<leader>av` | x | `send({ msg = "{selection}" })` | Send visual selection |
+| `<leader>ap` | n,x | `prompt()` | Select prompt |
+| `<leader>ac` | n | `toggle({ name = "claude" })` | Toggle Claude directly |
+
+**Implementation Pattern:**
+
+```lua
+-- Plugin file: nvim/lua/nairovim/plugins/ai/sidekick.lua
+config = function(_, opts)
+    require("sidekick").setup(opts)
+    
+    -- Load keymaps from customizations
+    local mappings = require("nairovim.plugins.customizations.keymaps.sidekick").mappings
+    local common_utils = require("nairovim.utils.common")
+    common_utils.map(mappings)
+end
+```
+
+**Files Structure:**
+
+```
+nvim/lua/nairovim/plugins/
+├── ai/
+│   └── sidekick.lua              # Plugin configuration + tool overrides
+└── customizations/
+    └── keymaps/
+        └── sidekick.lua          # All keybindings (nairovim.KeymapDef[])
+```
+
+**Impact:** Clean separation of concerns, follows project conventions, maintainable keymap organization  
+**Branch:** `feat/sidekick-ctrl-p-fix`  
+**Files:** 2 new files (sidekick.lua, keymaps/sidekick.lua)  
+**Line changes:** +152 lines total  
+**Commits:** 2 commits (plugin config + lazy-lock update)
+
+---
+
+## 2026-02-28: Sidekick OpenCode Ctrl+P Fix
+**Goal:** Enable OpenCode's native Ctrl+P command list functionality when running in sidekick terminal
+
+Applied official fix from upstream PR #176 to resolve keybinding conflict where sidekick's prompt picker was intercepting Ctrl+P before it could reach OpenCode's TUI. OpenCode v1.0.15+ uses Ctrl+P for its built-in command list menu.
+
+**Root Cause:**
+
+Sidekick's default terminal keybindings included `prompt = { "<c-p>", "prompt", mode = "t" }` which intercepted Ctrl+P in ALL terminal sessions. When OpenCode runs inside a sidekick terminal, this prevented OpenCode's native Ctrl+P functionality from working.
+
+**Why Setting `prompt = false` Didn't Work:**
+
+Initial attempts to set `opts.cli.win.keys.prompt = false` in user config were insufficient because:
+1. Sidekick's tool-specific defaults have higher precedence in the merge order
+2. The keybinding wasn't being created, but no alternative was configured
+3. Result: Ctrl+P did nothing (neither sidekick nor OpenCode handled it)
+
+**Solution Applied (PR #176):**
+
+Modified user config to override Ctrl+P for OpenCode tool specifically using tool-specific configuration:
+
+```lua
+-- File: nvim/lua/nairovim/plugins/ai/sidekick.lua
+tools = {
+    opencode = {
+        -- OpenCode uses <c-p> for its own command list functionality
+        -- Override sidekick's default to use Alt+P instead
+        keys = { prompt = { "<a-p>", "prompt" } },
+    },
+}
+```
+
+This follows the same pattern as the `crush` tool (which also needs Ctrl+P for native functionality).
+
+**Changes Made:**
+
+1. **Sidekick Config** (`nvim/lua/nairovim/plugins/ai/sidekick.lua` lines 18-22):
+   - Added tool-specific OpenCode override: `keys = { prompt = { "<a-p>", "prompt" } }`
+   - Frees Ctrl+P for OpenCode, moves sidekick prompt picker to Alt+P
+
+2. **Zellij Config** (`~/.config/zellij/config.kdl`):
+   - Commented out line 21: `bind "Ctrl p" { SwitchToMode "normal"; }` in pane mode
+   - Commented out line 175: `bind "Ctrl p" { SwitchToMode "pane"; }` in shared bindings
+   - Reason: Zellij was intercepting Ctrl+P before it could reach OpenCode terminal
+   - User doesn't actively use Zellij pane mode, so removing this binding has no impact
+   - Backup created at `~/.config/zellij/config.kdl.backup`
+
+**Result:**
+
+- ✅ Ctrl+P in OpenCode terminal → Opens OpenCode command list
+- ✅ Alt+P in OpenCode terminal → Opens sidekick prompt/context picker
+- ✅ Ctrl+P in other AI tools (Claude, Copilot) → Opens sidekick prompt picker (default behavior)
+- ✅ Works with Zellij backend (no tmux colorscheme issues)
+- ✅ Configuration will align with upstream when PR #176 merges
+
+**Testing:**
+
+```bash
+# 1. Open OpenCode via sidekick
+:lua require("sidekick.cli").toggle("opencode")
+
+# 2. In terminal mode, press Ctrl+P
+# Expected: OpenCode command list appears ✅
+
+# 3. In terminal mode, press Alt+P
+# Expected: Sidekick prompt picker appears ✅
+
+# 4. Verify keybinding
+:verbose map <c-p>
+# In terminal mode: No sidekick mapping (passes through to OpenCode)
+```
+
+**Impact:** OpenCode's native Ctrl+P command list now works correctly in sidekick terminals  
+**Reference:** [GitHub Issue #175](https://github.com/folke/sidekick.nvim/issues/175) | [PR #176](https://github.com/folke/sidekick.nvim/pull/176)  
+**Files:** 2 files modified (sidekick.lua, zellij config.kdl)  
+**Line changes:** +5 lines (sidekick.lua), 2 lines commented (zellij config.kdl)
+
+---
+
 ## 2026-02-12: FZF Ctrl+R Command History Fix (WSL)
 **Goal:** Fix `Ctrl+R` command history search not working in WSL with Vi mode enabled
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,9 @@ Implemented full sidekick.nvim configuration with zellij backend, tool-specific 
    - Preferred over tmux to avoid colorscheme rendering issues
    - Enabled with `mux.backend = "zellij"`
    - Full multiplexer session support
+   - **Windows Compatibility**: Disabled on Windows native (`enabled = vim.fn.has("win32") == 0`)
+   - Zellij has no Windows native build, only Linux/macOS binaries
+   - WSL users still get full zellij support
 
 2. **Terminal Window Layout**:
    - Position: Right side of screen (`layout = "right"`)
@@ -76,7 +79,7 @@ nvim/lua/nairovim/plugins/
 **Branch:** `feat/sidekick-ctrl-p-fix`  
 **Files:** 2 new files (sidekick.lua, keymaps/sidekick.lua)  
 **Line changes:** +152 lines total  
-**Commits:** 2 commits (plugin config + lazy-lock update)
+**Commits:** 4 commits (plugin config, lazy-lock update, Windows compatibility fix, install script fix)
 
 ---
 

--- a/install.ps1
+++ b/install.ps1
@@ -521,15 +521,6 @@ function Install-Neovim {
     Print-Success "Neovim installation and configuration complete!"
 }
 
-function Install-Zellij {
-    Print-Section "$($Symbols.Gear) Installing Zellij"
-    
-    Install-WithScoop -Package "zellij" -DisplayName "Zellij"
-    
-    Write-Host ""
-    Print-Success "Zellij installation complete!"
-}
-
 function Install-WindowsTerminal {
     Print-Section "$($Symbols.Gear) Installing Windows Terminal"
     
@@ -1070,7 +1061,7 @@ function Print-InstallationSummary {
     Write-Host "$($Symbols.CheckMark) Development tools installed (Node.js, Go, Python) [optional]"
     Write-Host "$($Symbols.CheckMark) Dotfiles linked (.ripgreprc, scooter config)"
     Write-Host "$($Symbols.CheckMark) Neovim installed and configured"
-    Write-Host "$($Symbols.CheckMark) Zellij installed (terminal multiplexer)"
+    Write-Host "$($Symbols.CheckMark) Zellij: not available on Windows native (use via WSL)"
     Write-Host "$($Symbols.CheckMark) Windows Terminal installed and configured"
     Write-Host "$($Symbols.CheckMark) Oh My Posh installed with TokyoNight theme"
     Write-Host "$($Symbols.CheckMark) CLI tools installed (fzf, ripgrep, bat, git, lazygit)"
@@ -1136,7 +1127,6 @@ function Main {
     Install-DevelopmentTools
     Install-Dotfiles
     Install-Neovim
-    Install-Zellij
     Install-WindowsTerminal
     Install-OhMyPosh
     Install-CLITools

--- a/install.ps1
+++ b/install.ps1
@@ -521,6 +521,15 @@ function Install-Neovim {
     Print-Success "Neovim installation and configuration complete!"
 }
 
+function Install-Zellij {
+    Print-Section "$($Symbols.Gear) Installing Zellij"
+    
+    Install-WithScoop -Package "zellij" -DisplayName "Zellij"
+    
+    Write-Host ""
+    Print-Success "Zellij installation complete!"
+}
+
 function Install-WindowsTerminal {
     Print-Section "$($Symbols.Gear) Installing Windows Terminal"
     
@@ -1061,6 +1070,7 @@ function Print-InstallationSummary {
     Write-Host "$($Symbols.CheckMark) Development tools installed (Node.js, Go, Python) [optional]"
     Write-Host "$($Symbols.CheckMark) Dotfiles linked (.ripgreprc, scooter config)"
     Write-Host "$($Symbols.CheckMark) Neovim installed and configured"
+    Write-Host "$($Symbols.CheckMark) Zellij installed (terminal multiplexer)"
     Write-Host "$($Symbols.CheckMark) Windows Terminal installed and configured"
     Write-Host "$($Symbols.CheckMark) Oh My Posh installed with TokyoNight theme"
     Write-Host "$($Symbols.CheckMark) CLI tools installed (fzf, ripgrep, bat, git, lazygit)"
@@ -1126,6 +1136,7 @@ function Main {
     Install-DevelopmentTools
     Install-Dotfiles
     Install-Neovim
+    Install-Zellij
     Install-WindowsTerminal
     Install-OhMyPosh
     Install-CLITools

--- a/install.ps1
+++ b/install.ps1
@@ -521,6 +521,70 @@ function Install-Neovim {
     Print-Success "Neovim installation and configuration complete!"
 }
 
+function Install-PSMux {
+    Print-Section "$($Symbols.Gear) Installing psmux (tmux for Windows)"
+    
+    # Check if psmux is already installed
+    if (Test-Command "psmux") {
+        Print-Info "psmux is already installed, skipping..."
+        return
+    }
+    
+    # Try winget first (preferred method)
+    if (Test-Command "winget") {
+        Print-Step "Installing psmux" "via winget"
+        try {
+            winget install --id psmux --silent --accept-package-agreements --accept-source-agreements 2>&1 | Out-Null
+            if (Test-Command "psmux") {
+                Print-Success "psmux installed successfully via winget"
+                return
+            }
+        }
+        catch {
+            Print-Warning "winget installation failed, trying Chocolatey..."
+        }
+    }
+    
+    # Try Chocolatey as fallback
+    if (Test-Command "choco") {
+        Print-Step "Installing psmux" "via Chocolatey"
+        try {
+            choco install psmux -y 2>&1 | Out-Null
+            if (Test-Command "psmux") {
+                Print-Success "psmux installed successfully via Chocolatey"
+                return
+            }
+        }
+        catch {
+            Print-Warning "Chocolatey installation failed, trying Cargo..."
+        }
+    }
+    
+    # Try Cargo as last resort
+    if (Test-Command "cargo") {
+        Print-Step "Installing psmux" "via Cargo"
+        try {
+            cargo install psmux 2>&1 | Out-Null
+            if (Test-Command "psmux") {
+                Print-Success "psmux installed successfully via Cargo"
+                return
+            }
+        }
+        catch {
+            Print-Error "Failed to install psmux via Cargo"
+        }
+    }
+    
+    # If we get here, all methods failed
+    Print-Warning "Could not install psmux automatically. Please install manually:"
+    Print-Info "  Option 1: winget install psmux"
+    Print-Info "  Option 2: choco install psmux"
+    Print-Info "  Option 3: cargo install psmux"
+    Print-Info "  Option 4: Download from https://github.com/marlocarlo/psmux/releases"
+    
+    Write-Host ""
+}
+
 function Install-WindowsTerminal {
     Print-Section "$($Symbols.Gear) Installing Windows Terminal"
     
@@ -1061,7 +1125,7 @@ function Print-InstallationSummary {
     Write-Host "$($Symbols.CheckMark) Development tools installed (Node.js, Go, Python) [optional]"
     Write-Host "$($Symbols.CheckMark) Dotfiles linked (.ripgreprc, scooter config)"
     Write-Host "$($Symbols.CheckMark) Neovim installed and configured"
-    Write-Host "$($Symbols.CheckMark) Zellij: not available on Windows native (use via WSL)"
+    Write-Host "$($Symbols.CheckMark) psmux installed (tmux-compatible multiplexer for Windows)"
     Write-Host "$($Symbols.CheckMark) Windows Terminal installed and configured"
     Write-Host "$($Symbols.CheckMark) Oh My Posh installed with TokyoNight theme"
     Write-Host "$($Symbols.CheckMark) CLI tools installed (fzf, ripgrep, bat, git, lazygit)"
@@ -1127,6 +1191,7 @@ function Main {
     Install-DevelopmentTools
     Install-Dotfiles
     Install-Neovim
+    Install-PSMux
     Install-WindowsTerminal
     Install-OhMyPosh
     Install-CLITools

--- a/install.sh
+++ b/install.sh
@@ -619,6 +619,15 @@ install_tmux() {
     print_success "Tmux and TPM setup complete!"
 }
 
+install_zellij() {
+    print_section "${GEAR} Installing Zellij"
+
+    install_with_brew "zellij" "Zellij"
+
+    echo ""
+    print_success "Zellij installation complete!"
+}
+
 install_oh_my_zsh() {
     print_section "${SPARKLES} Installing Oh My Zsh"
 
@@ -1236,6 +1245,7 @@ print_installation_summary() {
     echo "${green}${CHECK_MARK}${textreset} Dotfiles linked (.zshrc, .vimrc, .tmux.conf, .ripgreprc)"
     echo "${green}${CHECK_MARK}${textreset} Neovim installed and configured"
     echo "${green}${CHECK_MARK}${textreset} Tmux installed with Plugin Manager (TPM)"
+    echo "${green}${CHECK_MARK}${textreset} Zellij installed (terminal multiplexer)"
     echo "${green}${CHECK_MARK}${textreset} Oh My Zsh installed"
     echo "${green}${CHECK_MARK}${textreset} CLI tools installed (fzf, ripgrep, bat, scooter)"
     echo "${green}${CHECK_MARK}${textreset} UV/UVX installed for MCP plugins"
@@ -1303,6 +1313,7 @@ main() {
     install_dotfiles
     install_neovim
     install_tmux
+    install_zellij
     install_oh_my_zsh
     install_cli_tools
     install_uv

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -45,6 +45,7 @@
   "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },
   "quick-scope": { "branch": "master", "commit": "6cee1d9e0b9ac0fbffeb538d4a5ba9f5628fabbc" },
   "render-markdown.nvim": { "branch": "main", "commit": "1c958131c083c8557ea499fdb08c88b8afb05c4e" },
+  "sidekick.nvim": { "branch": "main", "commit": "c2bdf8cfcd87a6be5f8b84322c1b5052e78e302e" },
   "snacks.nvim": { "branch": "main", "commit": "fe7cfe9800a182274d0f868a74b7263b8c0c020b" },
   "telescope-fzf-native.nvim": { "branch": "main", "commit": "6fea601bd2b694c6f2ae08a6c6fab14930c60e2c" },
   "telescope.nvim": { "branch": "0.1.x", "commit": "a0bbec21143c7bc5f8bb02e0005fa0b982edc026" },

--- a/nvim/lua/nairovim/plugins/ai/sidekick.lua
+++ b/nvim/lua/nairovim/plugins/ai/sidekick.lua
@@ -4,10 +4,9 @@ return {
         -- add any options here
         cli = {
             mux = {
-                backend = "zellij",
-                -- backend = "tmux",
-                -- Disable on Windows native (Zellij not available), keep enabled on macOS/Linux/WSL
-                enabled = vim.fn.has("win32") == 0,
+                -- Platform-specific backend: psmux (tmux-compatible) on Windows, zellij on macOS/Linux
+                backend = vim.fn.has("win32") == 1 and "tmux" or "zellij",
+                enabled = true,
             },
             win = {
                 layout = "right", -- Terminal appears on right side

--- a/nvim/lua/nairovim/plugins/ai/sidekick.lua
+++ b/nvim/lua/nairovim/plugins/ai/sidekick.lua
@@ -6,7 +6,8 @@ return {
             mux = {
                 backend = "zellij",
                 -- backend = "tmux",
-                enabled = true,
+                -- Disable on Windows native (Zellij not available), keep enabled on macOS/Linux/WSL
+                enabled = vim.fn.has("win32") == 0,
             },
             win = {
                 layout = "right", -- Terminal appears on right side

--- a/nvim/lua/nairovim/plugins/ai/sidekick.lua
+++ b/nvim/lua/nairovim/plugins/ai/sidekick.lua
@@ -1,0 +1,47 @@
+return {
+    "folke/sidekick.nvim",
+    opts = {
+        -- add any options here
+        cli = {
+            mux = {
+                backend = "zellij",
+                -- backend = "tmux",
+                enabled = true,
+            },
+            win = {
+                layout = "right", -- Terminal appears on right side
+                split = {
+                    width = 0.45, -- 45% of screen width (matches OpenCode config)
+                    height = 0, -- Full height (0 = auto)
+                },
+            },
+            tools = {
+                opencode = {
+                    -- OpenCode uses <c-p> for its own command list functionality
+                    -- Override sidekick's default to use Alt+P instead
+                    keys = { prompt = { "<a-p>", "prompt" } },
+                },
+                copilot = {
+                    cmd = { "agency", "copilot" },
+                    -- Optional: custom keymaps for this tool
+                    keys = {
+                        submit = {
+                            "<c-s>",
+                            function(t)
+                                t:send("\n")
+                            end,
+                        },
+                    },
+                },
+            },
+        },
+    },
+    config = function(_, opts)
+        require("sidekick").setup(opts)
+
+        -- Load keymaps from customizations
+        local mappings = require("nairovim.plugins.customizations.keymaps.sidekick").mappings
+        local common_utils = require("nairovim.utils.common")
+        common_utils.map(mappings)
+    end,
+}

--- a/nvim/lua/nairovim/plugins/customizations/keymaps/sidekick.lua
+++ b/nvim/lua/nairovim/plugins/customizations/keymaps/sidekick.lua
@@ -1,0 +1,105 @@
+----------------------------------------------------------------------
+-- Sidekick AI Keymaps (nairovim.KeymapDef[])
+----------------------------------------------------------------------
+local M = {}
+
+---@type nairovim.KeymapDef[]
+M.mappings = {
+    -- NES (Next Edit Suggestion) - Jump or Apply
+    {
+        mode = "n",
+        key_sequence = "<tab>",
+        handler = function()
+            -- if there is a next edit, jump to it, otherwise apply it if any
+            if not require("sidekick").nes_jump_or_apply() then
+                return "<Tab>" -- fallback to normal tab
+            end
+        end,
+        opts = { expr = true, desc = "Goto/Apply Next Edit Suggestion" },
+    },
+    -- Sidekick Toggle (all modes)
+    {
+        mode = { "n", "t", "i", "x" },
+        key_sequence = "<c-.>",
+        handler = function()
+            require("sidekick.cli").toggle()
+        end,
+        opts = { desc = "Sidekick Toggle" },
+    },
+    -- Sidekick Toggle CLI
+    {
+        mode = "n",
+        key_sequence = "<leader>aa",
+        handler = function()
+            require("sidekick.cli").toggle()
+        end,
+        opts = { desc = "Sidekick Toggle CLI" },
+    },
+    -- Select CLI Tool
+    {
+        mode = "n",
+        key_sequence = "<leader>as",
+        handler = function()
+            require("sidekick.cli").select()
+            -- Or to select only installed tools:
+            -- require("sidekick.cli").select({ filter = { installed = true } })
+        end,
+        opts = { desc = "Select CLI" },
+    },
+    -- Detach/Close CLI Session
+    {
+        mode = "n",
+        key_sequence = "<leader>ad",
+        handler = function()
+            require("sidekick.cli").close()
+        end,
+        opts = { desc = "Detach a CLI Session" },
+    },
+    -- Send This (current context)
+    {
+        mode = { "x", "n" },
+        key_sequence = "<leader>at",
+        handler = function()
+            require("sidekick.cli").send({ msg = "{this}" })
+        end,
+        opts = { desc = "Send This" },
+    },
+    -- Send File
+    {
+        mode = "n",
+        key_sequence = "<leader>af",
+        handler = function()
+            require("sidekick.cli").send({ msg = "{file}" })
+        end,
+        opts = { desc = "Send File" },
+    },
+    -- Send Visual Selection
+    {
+        mode = "x",
+        key_sequence = "<leader>av",
+        handler = function()
+            require("sidekick.cli").send({ msg = "{selection}" })
+        end,
+        opts = { desc = "Send Visual Selection" },
+    },
+    -- Select Prompt
+    {
+        mode = { "n", "x" },
+        key_sequence = "<leader>ap",
+        handler = function()
+            require("sidekick.cli").prompt()
+        end,
+        opts = { desc = "Sidekick Select Prompt" },
+    },
+    -- Toggle Claude directly
+    {
+        mode = "n",
+        key_sequence = "<leader>ac",
+        handler = function()
+            require("sidekick.cli").toggle({ name = "claude", focus = true })
+        end,
+        opts = { desc = "Sidekick Toggle Claude" },
+    },
+}
+
+return M

--- a/nvim/lua/nairovim/plugins/snacks.lua
+++ b/nvim/lua/nairovim/plugins/snacks.lua
@@ -51,57 +51,87 @@ You are in %s
                             string.upper(cwd)
                         )
                     end)(),
-                    keys = {
-                        {
-                            icon = " ",
-                            key = "f",
-                            desc = "Find File",
-                            action = ":lua Snacks.dashboard.pick('files')",
-                        },
-                        { icon = " ", key = "n", desc = "New File", action = ":ene | startinsert" },
-                        {
-                            icon = "📚",
-                            key = "t",
-                            desc = "Interactive Tutorial",
-                            action = ":lua require('nairovim.utils.tutorial').start()",
-                        },
-                        { icon = " ", key = "F", desc = "Find/Replace", action = ":FindReplace" },
-                        {
-                            icon = " ",
-                            key = "g",
-                            desc = "Fuzzy Find Text",
-                            action = ":lua Snacks.dashboard.pick('live_grep')",
-                        },
-                        {
-                            icon = " ",
-                            key = "r",
-                            desc = "Recent Files",
-                            action = ":lua Snacks.dashboard.pick('oldfiles')",
-                        },
-                        {
-                            icon = " ",
-                            key = "G",
-                            desc = "Git",
-                            action = ":lua Snacks.lazygit()",
-                        },
-                        {
-                            icon = " ",
-                            key = "O",
-                            desc = "Opencode.ai - (GitHub Copilot)",
-                            action = ":lua require('opencode').toggle()",
-                        },
-                        { icon = "󰒲 ", key = "l", desc = "Lazy", action = ":Lazy" },
-                        {
-                            icon = " ",
-                            key = "c",
-                            desc = "Config",
-                            action = ":lua Snacks.dashboard.pick('files', {cwd = vim.fn.stdpath('config')})",
-                        },
-                        { icon = " ", key = "s", desc = "Restore Session", section = "session" },
-                        -- { icon = " ", key = "x", desc = "Lazy Extras", action = ":LazyExtras" },
-                        { icon = " ", key = "m", desc = "Mason", action = ":Mason" },
-                        { icon = " ", key = "q", desc = "Quit", action = ":qa" },
-                    },
+                    keys = (function()
+                        local keys_before = {
+                            {
+                                icon = " ",
+                                key = "f",
+                                desc = "Find File",
+                                action = ":lua Snacks.dashboard.pick('files')",
+                            },
+                            { icon = " ", key = "n", desc = "New File", action = ":ene | startinsert" },
+                            {
+                                icon = "📚",
+                                key = "t",
+                                desc = "Interactive Tutorial",
+                                action = ":lua require('nairovim.utils.tutorial').start()",
+                            },
+                            { icon = " ", key = "F", desc = "Find/Replace", action = ":FindReplace" },
+                            {
+                                icon = " ",
+                                key = "g",
+                                desc = "Fuzzy Find Text",
+                                action = ":lua Snacks.dashboard.pick('live_grep')",
+                            },
+                            {
+                                icon = " ",
+                                key = "r",
+                                desc = "Recent Files",
+                                action = ":lua Snacks.dashboard.pick('oldfiles')",
+                            },
+                            {
+                                icon = " ",
+                                key = "G",
+                                desc = "Git",
+                                action = ":lua Snacks.lazygit()",
+                            },
+                        }
+
+                        -- Platform-aware AI tool entries
+                        local ai_entries = vim.fn.has("win32") == 1 and {
+                            {
+                                icon = " ",
+                                key = "O",
+                                desc = "OpenCode (Preferred)",
+                                action = ":lua require('opencode').toggle()",
+                            },
+                            {
+                                icon = " ",
+                                key = "A",
+                                desc = "Agency CLI (Preview)",
+                                action = ":lua require('sidekick.cli').select()",
+                            },
+                        } or {
+                            {
+                                icon = " ",
+                                key = "A",
+                                desc = "Agency CLI (Preferred)",
+                                action = ":lua require('sidekick.cli').select()",
+                            },
+                            {
+                                icon = " ",
+                                key = "O",
+                                desc = "OpenCode",
+                                action = ":lua require('opencode').toggle()",
+                            },
+                        }
+
+                        local keys_after = {
+                            { icon = "󰒲 ", key = "l", desc = "Lazy", action = ":Lazy" },
+                            {
+                                icon = " ",
+                                key = "c",
+                                desc = "Config",
+                                action = ":lua Snacks.dashboard.pick('files', {cwd = vim.fn.stdpath('config')})",
+                            },
+                            { icon = " ", key = "s", desc = "Restore Session", section = "session" },
+                            -- { icon = " ", key = "x", desc = "Lazy Extras", action = ":LazyExtras" },
+                            { icon = " ", key = "m", desc = "Mason", action = ":Mason" },
+                            { icon = " ", key = "q", desc = "Quit", action = ":qa" },
+                        }
+
+                        return vim.list_extend(vim.list_extend(keys_before, ai_entries), keys_after)
+                    end)(),
                 },
             },
         })


### PR DESCRIPTION
## What does this PR do?

Integrates sidekick.nvim as a comprehensive AI tool multiplexer with platform-specific optimizations and adds platform-aware dashboard entries for OpenCode and Agency CLI. This provides users with a unified interface to access multiple AI coding assistants (OpenCode, Claude, GitHub Copilot, etc.) through a single terminal session with proper keybinding management.

- Add complete sidekick.nvim plugin configuration with 10 keybindings
- Implement platform-specific multiplexer backends (psmux on Windows, zellij on macOS/Linux)
- Fix OpenCode Ctrl+P keybinding conflict (sidekick uses Alt+P for OpenCode tool)
- Add platform-aware dashboard AI entries (Windows: OpenCode preferred, macOS/Linux: Agency CLI preferred)
- Install psmux for Windows and zellij for macOS/Linux via installation scripts
- Extract sidekick keymaps to customizations directory following project conventions
- Preserve all Nerd Font icons in dashboard entries

## Why is it needed?

- **Keybinding Conflict Resolution**: OpenCode v1.0.15+ uses Ctrl+P for its native command list, which conflicted with sidekick's prompt picker. Tool-specific override frees Ctrl+P for OpenCode while using Alt+P for sidekick.
- **Cross-Platform Multiplexer Support**: Windows requires psmux (tmux-compatible), while macOS/Linux benefit from zellij (no colorscheme issues).
- **Unified AI Tool Access**: Agency CLI tool picker provides single entry point to all AI assistants, reducing cognitive overhead.
- **Platform-Appropriate Recommendations**: Dashboard shows most stable/feature-complete tool first based on platform capabilities.

## How have the changes been tested?

- ✅ Verified sidekick.nvim loads without errors on Linux
- ✅ Confirmed OpenCode Ctrl+P functionality works in sidekick terminal
- ✅ Tested sidekick Alt+P prompt picker opens correctly
- ✅ Validated platform detection logic (`vim.fn.has("win32")`)
- ✅ Verified all dashboard icons render correctly (13 original + 2 new AI entries)
- ✅ Tested zellij installation script on Linux
- ✅ Confirmed no LSP errors in modified files

## Checklist

- [x] Sidekick plugin configuration added with platform-specific backends
- [x] Tool-specific overrides (OpenCode Alt+P, Copilot Ctrl+S)
- [x] 10 sidekick keybindings extracted to customizations
- [x] Platform-aware dashboard entries implemented
- [x] psmux installation added to Windows install script
- [x] zellij installation added to macOS/Linux install script
- [x] All Nerd Font icons preserved in dashboard
- [x] AGENTS.md documentation updated with 2 entries
- [x] lazy-lock.json updated with sidekick.nvim
- [x] No LSP errors in modified Lua files
- [x] Follows conventional commit format (12 commits)