### PR TITLE
2026-03-02: Refactor Sidekick and Lualine Configuration

### DIFF
--- a/nvim/lua/nairovim/plugins/ai/sidekick.lua
+++ b/nvim/lua/nairovim/plugins/ai/sidekick.lua
@@ -11,7 +11,7 @@ return {
             win = {
                 layout = "right", -- Terminal appears on right side
                 split = {
-                    width = 0.45, -- 45% of screen width (matches OpenCode config)
+                    width = 0.35, -- 35% of screen width (matches OpenCode config)
                     height = 0, -- Full height (0 = auto)
                 },
             },

--- a/nvim/lua/nairovim/plugins/customizations/keymaps/sidekick.lua
+++ b/nvim/lua/nairovim/plugins/customizations/keymaps/sidekick.lua
@@ -17,6 +17,15 @@ M.mappings = {
         end,
         opts = { expr = true, desc = "Goto/Apply Next Edit Suggestion" },
     },
+    
+    {
+        mode = { "n", "x" },
+        key_sequence = "<leader>aF",
+        handler = function()
+            require("sidekick.cli").toggle()
+        end,
+        opts = { desc = "Sidekick Focus" },
+    },
     -- Sidekick Toggle (all modes)
     {
         mode = { "n", "t", "i", "x" },

--- a/nvim/lua/nairovim/plugins/lualine.lua
+++ b/nvim/lua/nairovim/plugins/lualine.lua
@@ -9,18 +9,22 @@ local Blank = {
         "packer",
         "filetree",
         "bufferlist",
-        "opencode",
-        "opencode_terminal",
         "NvimTree",
     },
 }
 
-local Snacks_Dashboard = {
+local GitBranch = {
     sections = {
         lualine_a = { "" },
         lualine_b = { "branch" },
     },
-    filetypes = { "snacks_dashboard" },
+    filetypes = {
+        "snacks_dashboard",
+        "snacks_terminal",
+        "opencode",
+        "opencode_terminal",
+        "sidekick_terminal",
+    },
 }
 
 return {
@@ -38,14 +42,9 @@ return {
                         path = 1, -- 0 = just filename, 1 = relative path, 2 = absolute path
                     },
                 },
-                lualine_z = {
-                    {
-                        require("opencode").statusline,
-                    },
-                },
             },
             extensions = {
-                Snacks_Dashboard,
+                GitBranch,
                 Blank,
             },
             -- options = { theme = "grubbox" },


### PR DESCRIPTION
## What does this PR do?

Refines sidekick terminal layout and lualine extensions for better screen utilization and consistent terminal styling across AI tools.

- Reduced sidekick terminal width from 45% to 35%
- Added `<leader>aF` keymap for sidekick focus/toggle
- Refactored lualine extensions to use GitBranch for all terminal filetypes
- Removed OpenCode statusline component from lualine_z section
- Applied GitBranch extension to snacks_terminal, opencode_terminal, sidekick_terminal

## Why is it needed?

35% terminal width provides better balance between editor and AI assistant. Unified lualine extension reduces duplication and ensures consistent branch display across all terminal types.

## How have the changes been tested?

- Verified sidekick terminal renders at 35% width
- Tested <leader>aF keymap toggles sidekick
- Confirmed branch display in all terminal filetypes

## Checklist

- [x] Adjusted sidekick width to 35%
- [x] Added focus keymap
- [x] Unified lualine extensions
- [x] Tested terminal rendering